### PR TITLE
Field Type Registry: Share custom types across instances

### DIFF
--- a/src/DataView/DataView.php
+++ b/src/DataView/DataView.php
@@ -70,8 +70,8 @@ class DataView {
      *   - ui: array - WordPress admin UI configuration
      *   - capability: string - required capability (default: 'manage_options')
      */
-    public function __construct( array $config ) {
-        $this->registry         = new FieldTypeRegistry();
+    public function __construct( array $config, ?FieldTypeRegistry $registry = null ) {
+        $this->registry         = $registry ?? new FieldTypeRegistry();
         $this->label_generator  = new LabelGenerator();
         $this->schema_generator = new SchemaGenerator( $this->registry );
 

--- a/src/DataView/FieldTypeRegistry.php
+++ b/src/DataView/FieldTypeRegistry.php
@@ -17,7 +17,7 @@ class FieldTypeRegistry {
     protected array $types = [];
 
     public function __construct() {
-        if ( empty( $this->types ) ) $this->register_default_types();
+        $this->register_default_types();
     }
 
     /**

--- a/src/DataView/FieldTypeRegistry.php
+++ b/src/DataView/FieldTypeRegistry.php
@@ -14,17 +14,17 @@ class FieldTypeRegistry {
      *
      * @var array<string, array{dataset: string, sanitizer: callable|string, schema: array, input: string}>
      */
-    protected static array $types = [];
+    protected array $types = [];
 
     public function __construct() {
-        if ( empty( static::$types ) ) $this->register_default_types();
+        if ( empty( $this->types ) ) $this->register_default_types();
     }
 
     /**
      * Register the default field types.
      */
     protected function register_default_types(): void {
-        static::$types = [
+        $this->types = [
             'string' => [
                 'dataset'   => DataSet::TYPE_STRING,
                 'sanitizer' => 'sanitize_text_field',
@@ -91,7 +91,7 @@ class FieldTypeRegistry {
      */
     public function get_dataset_type( string $type ): string {
         $this->validate_type( $type );
-        return static::$types[ $type ]['dataset'];
+        return $this->types[ $type ]['dataset'];
     }
 
     /**
@@ -103,7 +103,7 @@ class FieldTypeRegistry {
      */
     public function get_sanitizer( string $type ): callable {
         $this->validate_type( $type );
-        return static::$types[ $type ]['sanitizer'];
+        return $this->types[ $type ]['sanitizer'];
     }
 
     /**
@@ -115,7 +115,7 @@ class FieldTypeRegistry {
      */
     public function get_schema( string $type ): array {
         $this->validate_type( $type );
-        return static::$types[ $type ]['schema'];
+        return $this->types[ $type ]['schema'];
     }
 
     /**
@@ -127,7 +127,7 @@ class FieldTypeRegistry {
      */
     public function get_input_type( string $type ): string {
         $this->validate_type( $type );
-        return static::$types[ $type ]['input'];
+        return $this->types[ $type ]['input'];
     }
 
     /**
@@ -137,7 +137,7 @@ class FieldTypeRegistry {
      * @return bool True if type is registered.
      */
     public function has_type( string $type ): bool {
-        return isset( static::$types[ $type ] );
+        return isset( $this->types[ $type ] );
     }
 
     /**
@@ -155,7 +155,7 @@ class FieldTypeRegistry {
                 );
             }
         }
-        static::$types[ $name ] = $config;
+        $this->types[ $name ] = $config;
     }
 
     /**
@@ -167,7 +167,7 @@ class FieldTypeRegistry {
     protected function validate_type( string $type ): void {
         if ( ! $this->has_type( $type ) ) {
             throw new \InvalidArgumentException(
-                sprintf( 'Unknown field type "%s". Available types: %s', $type, implode( ', ', array_keys( static::$types ) ) )
+                sprintf( 'Unknown field type "%s". Available types: %s', $type, implode( ', ', array_keys( $this->types ) ) )
             );
         }
     }

--- a/src/DataView/FieldTypeRegistry.php
+++ b/src/DataView/FieldTypeRegistry.php
@@ -14,17 +14,17 @@ class FieldTypeRegistry {
      *
      * @var array<string, array{dataset: string, sanitizer: callable|string, schema: array, input: string}>
      */
-    protected array $types = [];
+    protected static array $types = [];
 
     public function __construct() {
-        $this->register_default_types();
+        if ( empty( static::$types ) ) $this->register_default_types();
     }
 
     /**
      * Register the default field types.
      */
     protected function register_default_types(): void {
-        $this->types = [
+        static::$types = [
             'string' => [
                 'dataset'   => DataSet::TYPE_STRING,
                 'sanitizer' => 'sanitize_text_field',
@@ -91,7 +91,7 @@ class FieldTypeRegistry {
      */
     public function get_dataset_type( string $type ): string {
         $this->validate_type( $type );
-        return $this->types[ $type ]['dataset'];
+        return static::$types[ $type ]['dataset'];
     }
 
     /**
@@ -103,7 +103,7 @@ class FieldTypeRegistry {
      */
     public function get_sanitizer( string $type ): callable {
         $this->validate_type( $type );
-        return $this->types[ $type ]['sanitizer'];
+        return static::$types[ $type ]['sanitizer'];
     }
 
     /**
@@ -115,7 +115,7 @@ class FieldTypeRegistry {
      */
     public function get_schema( string $type ): array {
         $this->validate_type( $type );
-        return $this->types[ $type ]['schema'];
+        return static::$types[ $type ]['schema'];
     }
 
     /**
@@ -127,7 +127,7 @@ class FieldTypeRegistry {
      */
     public function get_input_type( string $type ): string {
         $this->validate_type( $type );
-        return $this->types[ $type ]['input'];
+        return static::$types[ $type ]['input'];
     }
 
     /**
@@ -137,7 +137,7 @@ class FieldTypeRegistry {
      * @return bool True if type is registered.
      */
     public function has_type( string $type ): bool {
-        return isset( $this->types[ $type ] );
+        return isset( static::$types[ $type ] );
     }
 
     /**
@@ -155,7 +155,7 @@ class FieldTypeRegistry {
                 );
             }
         }
-        $this->types[ $name ] = $config;
+        static::$types[ $name ] = $config;
     }
 
     /**
@@ -167,7 +167,7 @@ class FieldTypeRegistry {
     protected function validate_type( string $type ): void {
         if ( ! $this->has_type( $type ) ) {
             throw new \InvalidArgumentException(
-                sprintf( 'Unknown field type "%s". Available types: %s', $type, implode( ', ', array_keys( $this->types ) ) )
+                sprintf( 'Unknown field type "%s". Available types: %s', $type, implode( ', ', array_keys( static::$types ) ) )
             );
         }
     }

--- a/tests/phpunit/data-view.php
+++ b/tests/phpunit/data-view.php
@@ -54,7 +54,7 @@ class DataView_TestCase extends \WP_UnitTestCase {
         $this->assertTrue( $registry->has_type( 'datetime' ) );
     }
 
-    public function test_field_type_registry_has_shared_custom_types(): void {
+    public function test_field_type_registry_has_custom_types(): void {
         $registry_1 = new FieldTypeRegistry();
         $registry_2 = new FieldTypeRegistry();
 
@@ -72,13 +72,16 @@ class DataView_TestCase extends \WP_UnitTestCase {
             'input'     => 'hidden',
         ] );
 
+        $this->assertTrue( $registry_1->has_type( 'custom_type_1' ) );
+        $this->assertTrue( $registry_2->has_type( 'custom_type_2' ) );
+
+        $this->assertFalse( $registry_1->has_type( 'custom_type_2' ) );
+        $this->assertFalse( $registry_2->has_type( 'custom_type_1' ) );
+
         foreach( [
             $registry_1,
             $registry_2
         ] as $registry ) {
-            $this->assertTrue( $registry->has_type( 'custom_type_1' ) );
-            $this->assertTrue( $registry->has_type( 'custom_type_2' ) );
-
             // Check defaults are not erased by custom
             $this->assertTrue( $registry->has_type( 'string' ) );
             $this->assertTrue( $registry->has_type( 'text' ) );
@@ -89,6 +92,38 @@ class DataView_TestCase extends \WP_UnitTestCase {
             $this->assertTrue( $registry->has_type( 'date' ) );
             $this->assertTrue( $registry->has_type( 'datetime' ) );
         }
+    }
+
+    public function test_dataview_can_use_field_registery_with_custom_types(): void {
+        $registry = new FieldTypeRegistry();
+        $registry->register_type( 'custom_type', [
+            'dataset'   => DataSet::TYPE_STRING,
+            'sanitizer' => fn( $value ) => ( $value ),
+            'schema'    => [],
+            'input'     => 'hidden',
+        ] );
+
+        $config = [
+            'slug'   => 'dv_test_custom_field_type',
+            'label'  => 'Item',
+            'fields' => [
+                'name'   => 'custom_type',
+                'title'  => 'string',
+            ]
+        ];
+
+        try {
+            $view_default_registry = new DataView( $config );
+            $this->fail( 'Expected InvalidArgumentException was not thrown' );
+        } catch ( \InvalidArgumentException $e ) {
+            $this->assertStringStartsWith(
+                'Unknown field type "custom_type"',
+                $e->getMessage()
+            );
+        }
+
+        $view_custom_registry = new DataView( $config, $registry );
+        $this->assertInstanceOf( DataView::class, $view_custom_registry );
     }
 
     public function test_field_type_registry_maps_to_dataset_types(): void {

--- a/tests/phpunit/data-view.php
+++ b/tests/phpunit/data-view.php
@@ -54,6 +54,43 @@ class DataView_TestCase extends \WP_UnitTestCase {
         $this->assertTrue( $registry->has_type( 'datetime' ) );
     }
 
+    public function test_field_type_registry_has_shared_custom_types(): void {
+        $registry_1 = new FieldTypeRegistry();
+        $registry_2 = new FieldTypeRegistry();
+
+        $registry_1->register_type( 'custom_type_1', [
+            'dataset'   => DataSet::TYPE_STRING,
+            'sanitizer' => fn( $value ) => ( $value ),
+            'schema'    => [],
+            'input'     => 'hidden',
+        ] );
+
+        $registry_2->register_type( 'custom_type_2', [
+            'dataset'   => DataSet::TYPE_INTEGER,
+            'sanitizer' => fn( $value ) => ( $value ),
+            'schema'    => [],
+            'input'     => 'hidden',
+        ] );
+
+        foreach( [
+            $registry_1,
+            $registry_2
+        ] as $registry ) {
+            $this->assertTrue( $registry->has_type( 'custom_type_1' ) );
+            $this->assertTrue( $registry->has_type( 'custom_type_2' ) );
+
+            // Check defaults are not erased by custom
+            $this->assertTrue( $registry->has_type( 'string' ) );
+            $this->assertTrue( $registry->has_type( 'text' ) );
+            $this->assertTrue( $registry->has_type( 'email' ) );
+            $this->assertTrue( $registry->has_type( 'url' ) );
+            $this->assertTrue( $registry->has_type( 'integer' ) );
+            $this->assertTrue( $registry->has_type( 'boolean' ) );
+            $this->assertTrue( $registry->has_type( 'date' ) );
+            $this->assertTrue( $registry->has_type( 'datetime' ) );
+        }
+    }
+
     public function test_field_type_registry_maps_to_dataset_types(): void {
         $registry = new FieldTypeRegistry();
 


### PR DESCRIPTION
Hi @zinigor!

I believe there is a small issue with the custom field types registration currently

According to [this example from the documentation](https://tangibleinc.github.io/object/advanced/custom-field-types#sharing-types-across-views), `FieldTypeRegistry` instances should share custom types:
```php
// Create and configure a shared registry
$registry = new \Tangible\DataView\FieldTypeRegistry();
$registry->register_type('phone', [...]);

// Use it for multiple views
$view1 = new DataView(['fields' => ['phone' => 'phone'], ...]);
$view2 = new DataView(['fields' => ['mobile' => 'phone'], ...]);
```

However, it does not seem to be the case currently as each instance hold its own types ([here](https://github.com/TangibleInc/object/blob/091e93a751567837d98cded44a6da070a96d7417/src/DataView/FieldTypeRegistry.php#L17))

This behavior prevents the use of custom fields, as `DataView` instantiate its own `FieldTypeRegistry` instance ([here](https://github.com/TangibleInc/object/blob/091e93a751567837d98cded44a6da070a96d7417/src/DataView/DataView.php#L74), inside the constructor) which will trigger a fatal error when reaching [this part](https://github.com/TangibleInc/object/blob/091e93a751567837d98cded44a6da070a96d7417/src/DataView/DataView.php#L103) if a field type is not registered

I switched types to a static attribute, as it seems to be the expected behavior and was the easiest way to fix the issue without introducing syntax changes

If you don't want to change `FieldTypeRegistry`, I can also change this PR to pass a `FieldTypeRegistry` instance as a second (and optional) parameter of `DataView`:

```php
$registry = new \Tangible\DataView\FieldTypeRegistry();
$registry->register_type('phone', [...]);

// Shared custom types
$view1 = new DataView(['fields' => ['phone' => 'phone'], ...], $registry);
$view2 = new DataView(['fields' => ['mobile' => 'phone'], ...], $registry);

// Only default types
$view2 = new DataView(['fields' => ['mobile' => 'phone'], ...]);
```