### PR TITLE
RequestRouter: POST Requests - Process POST request inside admin_init

### DIFF
--- a/src/DataView/DataView.php
+++ b/src/DataView/DataView.php
@@ -295,6 +295,8 @@ class DataView {
             ] );
         }
 
+        add_action( 'admin_init', [ $this->router, 'maybe_redirect' ] );
+
         // Register admin menu.
         $this->register_admin_menu();
 

--- a/src/DataView/RequestRouter.php
+++ b/src/DataView/RequestRouter.php
@@ -146,15 +146,15 @@ class RequestRouter {
     public function maybe_redirect(): void {
         $this->check_capability();
 
-        if ( ! $this->is_post_request() ) return;
+        if ( ! $this->request->is_post() ) return;
 
         if ( $this->config->is_singular() ) {
             $this->handle_settings_submit();
             return;
         }
 
-        $action = $this->url_builder->get_current_action();
-        $id     = $this->url_builder->get_current_id();
+        $action = $this->request->get_current_action();
+        $id     = $this->request->get_current_id();
 
         switch ( $action ) {
             case 'create':

--- a/src/DataView/RequestRouter.php
+++ b/src/DataView/RequestRouter.php
@@ -106,13 +106,19 @@ class RequestRouter {
     }
 
     /**
-     * Route the current request to the appropriate handler.
+     * Check capability.
      */
-    public function route(): void {
-        // Check capability.
+    protected function check_capability() {
         if ( ! current_user_can( $this->config->capability ) ) {
             wp_die( __( 'You do not have permission to access this page.' ) );
         }
+    }
+
+    /**
+     * Route the current request to the appropriate handler.
+     */
+    public function route(): void {
+        $this->check_capability();
 
         $action = $this->url_builder->get_current_action();
         $id     = $this->url_builder->get_current_id();
@@ -128,33 +134,51 @@ class RequestRouter {
     }
 
     /**
+     * POST requests will trigger a redirect so they have to be processed
+     * earlier than GET request, before any content is displayed
+     *
+     * @param string $action Current action.
+     * @param int|null $id Entity ID.
+     */
+    public function maybe_redirect(): void {
+        $this->check_capability();
+
+        if ( ! $this->is_post_request() ) return;
+
+        if ( $this->config->is_singular() ) {
+            $this->handle_settings_submit();
+            return;
+        }
+
+        $action = $this->url_builder->get_current_action();
+        $id     = $this->url_builder->get_current_id();
+
+        switch ( $action ) {
+            case 'create':
+                $this->handle_create_submit();
+                return;
+            case 'edit':
+                if ( $id !== null ) {
+                    $this->handle_edit_submit( $id );
+                    return;
+                }
+                break;
+            case 'delete':
+                if ( $id !== null ) {
+                    $this->handle_delete( $id );
+                    return;
+                }
+                break;
+        }
+    }
+
+    /**
      * Route plural (multi-entity) requests.
      *
      * @param string $action Current action.
      * @param int|null $id Entity ID.
      */
     protected function route_plural( string $action, ?int $id ): void {
-        // Handle POST submissions.
-        if ( $this->is_post_request() ) {
-            switch ( $action ) {
-                case 'create':
-                    $this->handle_create_submit();
-                    return;
-                case 'edit':
-                    if ( $id !== null ) {
-                        $this->handle_edit_submit( $id );
-                        return;
-                    }
-                    break;
-                case 'delete':
-                    if ( $id !== null ) {
-                        $this->handle_delete( $id );
-                        return;
-                    }
-                    break;
-            }
-        }
-
         // Handle GET requests.
         switch ( $action ) {
             case 'create':
@@ -184,11 +208,6 @@ class RequestRouter {
      * Route singular (single-entity) requests.
      */
     protected function route_singular(): void {
-        if ( $this->is_post_request() ) {
-            $this->handle_settings_submit();
-            return;
-        }
-
         $this->render_settings_form();
     }
 


### PR DESCRIPTION
Hi @zinigor!

It looks like there is a small issue with the way we handle POST request currently

Every `DataView` request is processed inside a menu or submenu render callback ([here](https://github.com/TangibleInc/object/blob/091e93a751567837d98cded44a6da070a96d7417/src/DataView/DataView.php#L307-L330))

It causes issues for POST requests because they trigger a redirection, and as we have already rendered content at this point it triggers the following error and the redirection fails:
```
Warning: Cannot modify header information - headers already sent by (output started at /var/www/html/tobet/wp-includes/fonts/class-wp-font-face.php:98) in /var/www/html/tobet/wp-includes/pluggable.php on line 1535
```
See associated screencast:
https://github.com/user-attachments/assets/b8a89d61-b4ad-4784-8022-2daf7ea6d344

As a fix, I moved POST request handling in a separate method called `maybe_redirect()`, which will be triggered earlier during  `admin_init` 