### PR TITLE
RequestRouter: Get params according to current method

### DIFF
--- a/src/DataView/Request.php
+++ b/src/DataView/Request.php
@@ -2,14 +2,41 @@
 
 namespace Tangible\DataView;
 
+use WP_REST_Request;
+
 /**
- * Represents the current HTTP request.
- *
- * For shared parameters (action, id), POST is checked first and GET is used
- * as a fallback. This lets forms carry the routing parameters in hidden
- * inputs rather than relying on the URL.
+ * Wraps a WP_REST_Request instance, gives access to parameters
+ * according to method and defines default values
  */
 class Request {
+
+    /**
+     * @see https://developer.wordpress.org/reference/classes/wp_rest_request/
+     */
+    protected WP_REST_Request $rest_request;
+
+    protected array $default_params = [
+        'id'        => null,
+        'action'    => 'list',
+        '_wpnonce'  => '',
+    ];
+
+    public function __construct() {
+        /**
+         * Simple implementation based on how WP_REST_Server::serve_request()
+         * instantiates WP_REST_Request
+         *
+         * @see https://developer.wordpress.org/reference/classes/wp_rest_server/serve_request/
+         */
+        $this->rest_request = new WP_REST_Request(
+            $_SERVER['REQUEST_METHOD'],
+            $_SERVER['PATH_INFO'] ?? '/'
+        );
+
+        $this->rest_request->set_default_params( $this->default_params );
+        $this->rest_request->set_query_params( wp_unslash( $_GET ) );
+        $this->rest_request->set_body_params( wp_unslash( $_POST ) );
+    }
 
     /**
      * Get the current action from the request.
@@ -17,8 +44,7 @@ class Request {
      * @return string Current action (defaults to 'list').
      */
     public function get_current_action(): string {
-        $action = $this->get_param( 'action' );
-        return $action !== null ? sanitize_key( $action ) : 'list';
+        return sanitize_key( (string) $this->rest_request->get_param( 'action' ) );
     }
 
     /**
@@ -27,7 +53,7 @@ class Request {
      * @return int|null Entity ID or null if not present.
      */
     public function get_current_id(): ?int {
-        $id = $this->get_param( 'id' );
+        $id = $this->rest_request->get_param( 'id' );
         return $id !== null ? (int) $id : null;
     }
 
@@ -35,29 +61,13 @@ class Request {
      * Get the WordPress nonce from the current request.
      */
     public function get_nonce(): string {
-        // phpcs:ignore WordPress.Security.NonceVerification.Missing
-        return (string) ( $_POST['_wpnonce'] ?? $_GET['_wpnonce'] ?? '' );
+        return (string) $this->rest_request->get_param( '_wpnonce' );
     }
 
     /**
      * Whether the current request is a POST request.
      */
     public function is_post(): bool {
-        return isset( $_SERVER['REQUEST_METHOD'] ) && $_SERVER['REQUEST_METHOD'] === 'POST';
-    }
-
-    /**
-     * Read a parameter, checking POST first, then GET.
-     */
-    protected function get_param( string $name ): ?string {
-        // phpcs:ignore WordPress.Security.NonceVerification.Missing
-        if ( isset( $_POST[ $name ] ) ) {
-            return (string) $_POST[ $name ];
-        }
-        // phpcs:ignore WordPress.Security.NonceVerification.Recommended
-        if ( isset( $_GET[ $name ] ) ) {
-            return (string) $_GET[ $name ];
-        }
-        return null;
+        return $this->rest_request->is_method( 'POST' );
     }
 }

--- a/src/DataView/Request.php
+++ b/src/DataView/Request.php
@@ -1,0 +1,63 @@
+<?php declare( strict_types=1 );
+
+namespace Tangible\DataView;
+
+/**
+ * Represents the current HTTP request.
+ *
+ * For shared parameters (action, id), POST is checked first and GET is used
+ * as a fallback. This lets forms carry the routing parameters in hidden
+ * inputs rather than relying on the URL.
+ */
+class Request {
+
+    /**
+     * Get the current action from the request.
+     *
+     * @return string Current action (defaults to 'list').
+     */
+    public function get_current_action(): string {
+        $action = $this->get_param( 'action' );
+        return $action !== null ? sanitize_key( $action ) : 'list';
+    }
+
+    /**
+     * Get the entity ID from the current request.
+     *
+     * @return int|null Entity ID or null if not present.
+     */
+    public function get_current_id(): ?int {
+        $id = $this->get_param( 'id' );
+        return $id !== null ? (int) $id : null;
+    }
+
+    /**
+     * Get the WordPress nonce from the current request.
+     */
+    public function get_nonce(): string {
+        // phpcs:ignore WordPress.Security.NonceVerification.Missing
+        return (string) ( $_POST['_wpnonce'] ?? $_GET['_wpnonce'] ?? '' );
+    }
+
+    /**
+     * Whether the current request is a POST request.
+     */
+    public function is_post(): bool {
+        return isset( $_SERVER['REQUEST_METHOD'] ) && $_SERVER['REQUEST_METHOD'] === 'POST';
+    }
+
+    /**
+     * Read a parameter, checking POST first, then GET.
+     */
+    protected function get_param( string $name ): ?string {
+        // phpcs:ignore WordPress.Security.NonceVerification.Missing
+        if ( isset( $_POST[ $name ] ) ) {
+            return (string) $_POST[ $name ];
+        }
+        // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+        if ( isset( $_GET[ $name ] ) ) {
+            return (string) $_GET[ $name ];
+        }
+        return null;
+    }
+}

--- a/src/DataView/RequestRouter.php
+++ b/src/DataView/RequestRouter.php
@@ -24,6 +24,7 @@ class RequestRouter {
     protected UrlBuilder $url_builder;
     protected Renderer $renderer;
     protected LabelGenerator $label_generator;
+    protected Request $request;
 
     /** @var callable|null */
     protected $layout_callback = null;
@@ -38,7 +39,8 @@ class RequestRouter {
         FieldTypeRegistry $registry,
         UrlBuilder $url_builder,
         ?Renderer $renderer = null,
-        ?LabelGenerator $label_generator = null
+        ?LabelGenerator $label_generator = null,
+        ?Request $request = null
     ) {
         $this->config          = $config;
         $this->dataset         = $dataset;
@@ -47,6 +49,7 @@ class RequestRouter {
         $this->url_builder     = $url_builder;
         $this->renderer        = $renderer ?? new HtmlRenderer();
         $this->label_generator = $label_generator ?? new LabelGenerator();
+        $this->request         = $request ?? new Request();
 
         $this->resolve_labels();
     }
@@ -114,8 +117,8 @@ class RequestRouter {
             wp_die( __( 'You do not have permission to access this page.' ) );
         }
 
-        $action = $this->url_builder->get_current_action();
-        $id     = $this->url_builder->get_current_id();
+        $action = $this->request->get_current_action();
+        $id     = $this->request->get_current_id();
 
         // Handle singular mode differently.
         if ( $this->config->is_singular() ) {
@@ -135,7 +138,7 @@ class RequestRouter {
      */
     protected function route_plural( string $action, ?int $id ): void {
         // Handle POST submissions.
-        if ( $this->is_post_request() ) {
+        if ( $this->request->is_post() ) {
             switch ( $action ) {
                 case 'create':
                     $this->handle_create_submit();
@@ -184,7 +187,7 @@ class RequestRouter {
      * Route singular (single-entity) requests.
      */
     protected function route_singular(): void {
-        if ( $this->is_post_request() ) {
+        if ( $this->request->is_post() ) {
             $this->handle_settings_submit();
             return;
         }
@@ -508,15 +511,6 @@ class RequestRouter {
     }
 
     /**
-     * Check if this is a POST request.
-     *
-     * @return bool True if POST request.
-     */
-    protected function is_post_request(): bool {
-        return isset( $_SERVER['REQUEST_METHOD'] ) && $_SERVER['REQUEST_METHOD'] === 'POST';
-    }
-
-    /**
      * Verify nonce for an action.
      *
      * @param string $action Action name.
@@ -525,8 +519,7 @@ class RequestRouter {
      */
     protected function verify_nonce( string $action, ?int $id = null ): bool {
         $nonce_action = $this->url_builder->get_nonce_action( $action, $id );
-        // phpcs:ignore WordPress.Security.NonceVerification.Missing
-        $nonce = $_POST['_wpnonce'] ?? $_GET['_wpnonce'] ?? '';
+        $nonce = $this->request->get_nonce();
         return wp_verify_nonce( $nonce, $nonce_action ) !== false;
     }
 

--- a/src/DataView/UrlBuilder.php
+++ b/src/DataView/UrlBuilder.php
@@ -51,30 +51,6 @@ class UrlBuilder {
     }
 
     /**
-     * Get the current action from the request.
-     *
-     * @return string Current action (defaults to 'list').
-     */
-    public function get_current_action(): string {
-        // phpcs:ignore WordPress.Security.NonceVerification.Recommended
-        return isset( $_GET['action'] ) ? sanitize_key( $_GET['action'] ) : 'list';
-    }
-
-    /**
-     * Get the entity ID from the current request.
-     *
-     * @return int|null Entity ID or null if not present.
-     */
-    public function get_current_id(): ?int {
-        // phpcs:ignore WordPress.Security.NonceVerification.Recommended
-        if ( ! isset( $_GET['id'] ) ) {
-            return null;
-        }
-        // phpcs:ignore WordPress.Security.NonceVerification.Recommended
-        return (int) $_GET['id'];
-    }
-
-    /**
      * Get the menu page slug.
      *
      * @return string Menu page slug.


### PR DESCRIPTION
Hi @zinigor!

It seems that we don't read POST parameters correctly

Regardless of if it's a POST or GET request, we get the action and id parameters from the url

This means we will default to the edit action on the edit screen (as it's the action in the url), regardless of the current POST action (edit, delete or create) we try to trigger

I don't think this PR will completely fix delete/create actions completely, as it seems we have an issue with the way we handle nonces

In DataView, we generate the following nonce for the edit form ([here](https://github.com/TangibleInc/object/blob/091e93a751567837d98cded44a6da070a96d7417/src/DataView/RequestRouter.php#L238)):
```php
wp_nonce_field( $this->url_builder->get_nonce_action( 'edit', $id ) );
```

We use the same `<form />` for `create`, `edit` and `delete` actions but we do expect the nonce action to be different for each:
```php
protected function handle_create_submit(): void {
    if ( ! $this->verify_nonce( 'create' ) ) {
        wp_die( 'Security check failed.' );
    }
    // ...
}

protected function handle_edit_submit( int $id ): void {
    if ( ! $this->verify_nonce( 'edit', $id ) ) {
        wp_die( 'Security check failed.' );
    }
    // ...
}

protected function handle_delete( int $id ): void {
    if ( ! $this->verify_nonce( 'delete', $id ) ) {
        wp_die( 'Security check failed.' );
    }
    // ...
}
```

I would like to validate that my changes are ok so far before continuing (to be sure I didn't misunderstand the approach). If my current changes seems ok to you and you agree with the issue, I will open a separate PR to look into the nonce later