### PR TITLE
POST Forms: Nonce fields according to current action

### DIFF
--- a/src/DataView/DataViewConfig.php
+++ b/src/DataView/DataViewConfig.php
@@ -298,6 +298,16 @@ class DataViewConfig {
     }
 
     /**
+     * Generate the nonce request field name for a given action.
+     *
+     * @param string $action Action name.
+     * @return string Nonce field name.
+     */
+    public function get_nonce_name( string $action ): string {
+        return '_wpnonce_' . $action;
+    }
+
+    /**
      * Get the admin menu label.
      *
      * @return string Menu label.

--- a/src/DataView/DataViewConfig.php
+++ b/src/DataView/DataViewConfig.php
@@ -283,6 +283,21 @@ class DataViewConfig {
     }
 
     /**
+     * Generate the nonce action name for a given action and optional ID.
+     *
+     * @param string $action Action name.
+     * @param int|null $id Entity ID.
+     * @return string Nonce action name.
+     */
+    public function get_nonce_action( string $action, ?int $id = null ): string {
+        $nonce = $this->get_menu_page() . '_' . $action;
+        if ( $id !== null ) {
+            $nonce .= '_' . $id;
+        }
+        return $nonce;
+    }
+
+    /**
      * Get the admin menu label.
      *
      * @return string Menu label.

--- a/src/DataView/Request.php
+++ b/src/DataView/Request.php
@@ -60,8 +60,8 @@ class Request {
     /**
      * Get the WordPress nonce from the current request.
      */
-    public function get_nonce(): string {
-        return (string) $this->rest_request->get_param( '_wpnonce' );
+    public function get_nonce( ?string $name = '_wpnonce' ): string {
+        return (string) $this->rest_request->get_param( $name );
     }
 
     /**

--- a/src/DataView/RequestRouter.php
+++ b/src/DataView/RequestRouter.php
@@ -257,7 +257,7 @@ class RequestRouter {
         }
 
         echo '<form method="post" action="' . esc_url( $this->url_builder->url( 'create' ) ) . '">';
-        wp_nonce_field( $this->config->get_nonce_action( 'create' ) );
+        $this->nonce_field( 'create' );
         echo $this->renderer->render_editor( $layout, $data );
         echo '</form>';
 
@@ -316,8 +316,8 @@ class RequestRouter {
         }
 
         echo '<form method="post" action="' . esc_url( $this->url_builder->url( 'edit', $id ) ) . '">';
-        wp_nonce_field( $this->config->get_nonce_action( 'edit', $id ) );
-        wp_nonce_field( $this->config->get_nonce_action( 'delete', $id ), '_wpnonce_delete' );
+        $this->nonce_field( 'edit', $id );
+        $this->nonce_field( 'delete', $id );
         echo '<input type="hidden" name="id" value="' . esc_attr( (string) $id ) . '">';
 
         echo $this->renderer->render_editor( $layout, $data );
@@ -358,7 +358,7 @@ class RequestRouter {
      * @param int $id Entity ID.
      */
     protected function handle_delete( int $id ): void {
-        if ( ! $this->verify_nonce( 'delete', $id, '_wpnonce_delete' ) ) {
+        if ( ! $this->verify_nonce( 'delete', $id ) ) {
             wp_die( 'Security check failed.' );
         }
 
@@ -390,7 +390,7 @@ class RequestRouter {
         }
 
         echo '<form method="post">';
-        wp_nonce_field( $this->config->get_nonce_action( 'update' ) );
+        $this->nonce_field( 'update' );
         echo $this->renderer->render_editor( $layout, $data );
         echo '</form>';
 
@@ -534,19 +534,28 @@ class RequestRouter {
     }
 
     /**
+     * Output a nonce field for an action.
+     *
+     * @param string $action Action name.
+     * @param int|null $id Entity ID.
+     */
+    protected function nonce_field( string $action, ?int $id = null ): void {
+        wp_nonce_field(
+            $this->config->get_nonce_action( $action, $id ),
+            $this->config->get_nonce_name( $action )
+        );
+    }
+
+    /**
      * Verify nonce for an action.
      *
      * @param string $action Action name.
      * @param int|null $id Entity ID.
      * @return bool True if nonce is valid.
      */
-    protected function verify_nonce(
-        string $action,
-        ?int $id = null,
-        ?string $name = '_wpnonce'
-    ): bool {
+    protected function verify_nonce( string $action, ?int $id = null ): bool {
         $nonce_action = $this->config->get_nonce_action( $action, $id );
-        $nonce = $this->request->get_nonce( $name );
+        $nonce = $this->request->get_nonce( $this->config->get_nonce_name( $action ) );
         return wp_verify_nonce( $nonce, $nonce_action ) !== false;
     }
 

--- a/src/DataView/RequestRouter.php
+++ b/src/DataView/RequestRouter.php
@@ -480,7 +480,9 @@ class RequestRouter {
         } );
 
         $layout->sidebar( function ( Sidebar $sidebar ) {
-            $sidebar->actions( [ 'save', 'delete' ] );
+            $this->request->get_current_action() === 'create'
+                ? $sidebar->actions( [ 'create' ] )
+                : $sidebar->actions( [ 'save', 'delete' ] );
         } );
     }
 

--- a/src/DataView/RequestRouter.php
+++ b/src/DataView/RequestRouter.php
@@ -257,7 +257,7 @@ class RequestRouter {
         }
 
         echo '<form method="post" action="' . esc_url( $this->url_builder->url( 'create' ) ) . '">';
-        wp_nonce_field( $this->url_builder->get_nonce_action( 'create' ) );
+        wp_nonce_field( $this->config->get_nonce_action( 'create' ) );
         echo $this->renderer->render_editor( $layout, $data );
         echo '</form>';
 
@@ -316,7 +316,7 @@ class RequestRouter {
         }
 
         echo '<form method="post" action="' . esc_url( $this->url_builder->url( 'edit', $id ) ) . '">';
-        wp_nonce_field( $this->url_builder->get_nonce_action( 'edit', $id ) );
+        wp_nonce_field( $this->config->get_nonce_action( 'edit', $id ) );
         echo '<input type="hidden" name="id" value="' . esc_attr( (string) $id ) . '">';
         echo $this->renderer->render_editor( $layout, $data );
         echo '</form>';
@@ -388,7 +388,7 @@ class RequestRouter {
         }
 
         echo '<form method="post">';
-        wp_nonce_field( $this->url_builder->get_nonce_action( 'update' ) );
+        wp_nonce_field( $this->config->get_nonce_action( 'update' ) );
         echo $this->renderer->render_editor( $layout, $data );
         echo '</form>';
 
@@ -519,7 +519,7 @@ class RequestRouter {
             $html .= '<td>';
             $html .= '<a href="' . esc_url( $this->url_builder->url( 'edit', $id ) ) . '">Edit</a>';
             $html .= ' | ';
-            $html .= '<a href="' . esc_url( $this->url_builder->url_with_nonce( 'delete', $id, $this->url_builder->get_nonce_action( 'delete', $id ) ) ) . '" onclick="return confirm(\'Are you sure?\');">Delete</a>';
+            $html .= '<a href="' . esc_url( $this->url_builder->url_with_nonce( 'delete', $id, $this->config->get_nonce_action( 'delete', $id ) ) ) . '" onclick="return confirm(\'Are you sure?\');">Delete</a>';
             $html .= '</td>';
 
             $html .= '</tr>';
@@ -537,7 +537,7 @@ class RequestRouter {
      * @return bool True if nonce is valid.
      */
     protected function verify_nonce( string $action, ?int $id = null ): bool {
-        $nonce_action = $this->url_builder->get_nonce_action( $action, $id );
+        $nonce_action = $this->config->get_nonce_action( $action, $id );
         $nonce = $this->request->get_nonce();
         return wp_verify_nonce( $nonce, $nonce_action ) !== false;
     }

--- a/src/DataView/RequestRouter.php
+++ b/src/DataView/RequestRouter.php
@@ -316,14 +316,9 @@ class RequestRouter {
         }
 
         echo '<form method="post" action="' . esc_url( $this->url_builder->url( 'edit', $id ) ) . '">';
-        if ( $this->request->get_current_action() === 'create' ) {
-            wp_nonce_field( $this->config->get_nonce_action( 'create' ) );
-        }
-        else {
-            wp_nonce_field( $this->config->get_nonce_action( 'edit', $id ) );
-            wp_nonce_field( $this->config->get_nonce_action( 'delete', $id ), '_wpnonce_delete' );
-            echo '<input type="hidden" name="id" value="' . esc_attr( (string) $id ) . '">';
-        }
+        wp_nonce_field( $this->config->get_nonce_action( 'edit', $id ) );
+        wp_nonce_field( $this->config->get_nonce_action( 'delete', $id ), '_wpnonce_delete' );
+        echo '<input type="hidden" name="id" value="' . esc_attr( (string) $id ) . '">';
 
         echo $this->renderer->render_editor( $layout, $data );
         echo '</form>';
@@ -552,8 +547,6 @@ class RequestRouter {
     ): bool {
         $nonce_action = $this->config->get_nonce_action( $action, $id );
         $nonce = $this->request->get_nonce( $name );
-        var_dump( $nonce );
-        var_dump( $nonce_action );
         return wp_verify_nonce( $nonce, $nonce_action ) !== false;
     }
 

--- a/src/DataView/RequestRouter.php
+++ b/src/DataView/RequestRouter.php
@@ -316,8 +316,15 @@ class RequestRouter {
         }
 
         echo '<form method="post" action="' . esc_url( $this->url_builder->url( 'edit', $id ) ) . '">';
-        wp_nonce_field( $this->config->get_nonce_action( 'edit', $id ) );
-        echo '<input type="hidden" name="id" value="' . esc_attr( (string) $id ) . '">';
+        if ( $this->request->get_current_action() === 'create' ) {
+            wp_nonce_field( $this->config->get_nonce_action( 'create' ) );
+        }
+        else {
+            wp_nonce_field( $this->config->get_nonce_action( 'edit', $id ) );
+            wp_nonce_field( $this->config->get_nonce_action( 'delete', $id ), '_wpnonce_delete' );
+            echo '<input type="hidden" name="id" value="' . esc_attr( (string) $id ) . '">';
+        }
+
         echo $this->renderer->render_editor( $layout, $data );
         echo '</form>';
 
@@ -356,7 +363,7 @@ class RequestRouter {
      * @param int $id Entity ID.
      */
     protected function handle_delete( int $id ): void {
-        if ( ! $this->verify_nonce( 'delete', $id ) ) {
+        if ( ! $this->verify_nonce( 'delete', $id, '_wpnonce_delete' ) ) {
             wp_die( 'Security check failed.' );
         }
 
@@ -538,9 +545,15 @@ class RequestRouter {
      * @param int|null $id Entity ID.
      * @return bool True if nonce is valid.
      */
-    protected function verify_nonce( string $action, ?int $id = null ): bool {
+    protected function verify_nonce(
+        string $action,
+        ?int $id = null,
+        ?string $name = '_wpnonce'
+    ): bool {
         $nonce_action = $this->config->get_nonce_action( $action, $id );
-        $nonce = $this->request->get_nonce();
+        $nonce = $this->request->get_nonce( $name );
+        var_dump( $nonce );
+        var_dump( $nonce_action );
         return wp_verify_nonce( $nonce, $nonce_action ) !== false;
     }
 

--- a/src/DataView/UrlBuilder.php
+++ b/src/DataView/UrlBuilder.php
@@ -49,28 +49,4 @@ class UrlBuilder {
         $url = $this->url( $action, $id );
         return wp_nonce_url( $url, $nonce_action );
     }
-
-    /**
-     * Get the menu page slug.
-     *
-     * @return string Menu page slug.
-     */
-    public function get_menu_page(): string {
-        return $this->menu_page;
-    }
-
-    /**
-     * Generate the nonce action name for a given action and optional ID.
-     *
-     * @param string $action Action name.
-     * @param int|null $id Entity ID.
-     * @return string Nonce action name.
-     */
-    public function get_nonce_action( string $action, ?int $id = null ): string {
-        $nonce = $this->menu_page . '_' . $action;
-        if ( $id !== null ) {
-            $nonce .= '_' . $id;
-        }
-        return $nonce;
-    }
 }

--- a/src/DataView/UrlBuilder.php
+++ b/src/DataView/UrlBuilder.php
@@ -47,6 +47,6 @@ class UrlBuilder {
      */
     public function url_with_nonce( string $action, ?int $id, string $nonce_action ): string {
         $url = $this->url( $action, $id );
-        return wp_nonce_url( $url, $nonce_action );
+        return wp_nonce_url( $url, $nonce_action, '_wpnonce_' . $action );
     }
 }

--- a/src/Renderer/TangibleFieldsRenderer.php
+++ b/src/Renderer/TangibleFieldsRenderer.php
@@ -279,6 +279,14 @@ class TangibleFieldsRenderer implements Renderer {
      */
     protected function render_action( string $action ): string {
         $config = match ( $action ) {
+            'create' => [
+                'label'   => __( 'Create', 'tangible-object' ),
+                'type'    => 'submit',
+                'name'    => 'action',
+                'value'   => 'create',
+                'class'   => 'button button-primary',
+                'onclick' => '',
+            ],
             'save' => [
                 'label'   => __( 'Save', 'tangible-object' ),
                 'type'    => 'submit',

--- a/src/Renderer/TangibleFieldsRenderer.php
+++ b/src/Renderer/TangibleFieldsRenderer.php
@@ -291,7 +291,7 @@ class TangibleFieldsRenderer implements Renderer {
                 'label'   => __( 'Save', 'tangible-object' ),
                 'type'    => 'submit',
                 'name'    => 'action',
-                'value'   => 'save',
+                'value'   => 'edit',
                 'class'   => 'button button-primary',
                 'onclick' => '',
             ],

--- a/tests/phpunit/data-view.php
+++ b/tests/phpunit/data-view.php
@@ -1587,7 +1587,7 @@ class DataView_TestCase extends \WP_UnitTestCase {
         $this->assertStringContainsString( '<button', $save_html );
         $this->assertStringContainsString( 'type="submit"', $save_html );
         $this->assertStringContainsString( 'name="action"', $save_html );
-        $this->assertStringContainsString( 'value="save"', $save_html );
+        $this->assertStringContainsString( 'value="edit"', $save_html );
         $this->assertStringContainsString( '>Save</button>', $save_html );
 
         // Test delete button.

--- a/tests/phpunit/data-view.php
+++ b/tests/phpunit/data-view.php
@@ -10,6 +10,9 @@ use Tangible\DataObject\Storage\OptionStorage;
 use Tangible\DataView\DataView;
 use Tangible\DataView\DataViewConfig;
 use Tangible\DataView\FieldTypeRegistry;
+use Tangible\DataView\Request;
+use Tangible\DataView\RequestRouter;
+use Tangible\EditorLayout\Layout;
 use Tangible\DataView\LabelGenerator;
 use Tangible\DataView\SchemaGenerator;
 use Tangible\DataView\UrlBuilder;
@@ -1266,6 +1269,80 @@ class DataView_TestCase extends \WP_UnitTestCase {
         $this->assertEquals( 'test_view_create', $config->get_nonce_action( 'create' ) );
         $this->assertEquals( 'test_view_edit_42', $config->get_nonce_action( 'edit', 42 ) );
         $this->assertEquals( 'test_view_delete_5', $config->get_nonce_action( 'delete', 5 ) );
+    }
+
+    /**
+     * ==========================================================================
+     * RequestRouter Default Layout Tests
+     * ==========================================================================
+     */
+
+    /**
+     * Get default layout structure according to action (create or edit)
+     */
+    private function build_default_layout_for_action( string $action ): array {
+        $request = new class( $action ) extends Request {
+            public function __construct( public string $current_action ) {}
+            public function get_current_action(): string {
+                return $this->current_action;
+            }
+        };
+
+        $config = new DataViewConfig( [
+            'slug'   => 'dv_layout_test',
+            'label'  => 'Book',
+            'fields' => [
+                'title' => 'string',
+                'author' => 'string'
+            ],
+        ] );
+
+        $dataset = new DataSet();
+        $dataset->add_string( 'title' );
+        $dataset->add_string( 'author' );
+
+        $router = new RequestRouter(
+            $config,
+            $dataset,
+            new PluralHandler( new PluralObject( $config->slug ) ),
+            new FieldTypeRegistry(),
+            new UrlBuilder( $config->get_menu_page() ),
+            request: $request
+        );
+
+        $method = new \ReflectionMethod( $router, 'build_default_layout' );
+        $method->setAccessible( true );
+        $layout = new Layout( $dataset );
+        $method->invoke( $router, $layout );
+
+        return $layout->get_structure();
+    }
+
+    public function test_build_default_layout_uses_create_action_for_create(): void {
+        $this->assertEquals(
+            [ 'create' ],
+            $this->build_default_layout_for_action( 'create' )['sidebar']['actions']
+        );
+    }
+
+    public function test_build_default_layout_uses_save_and_delete_for_edit(): void {
+        $this->assertEquals(
+            [ 'save', 'delete' ],
+            $this->build_default_layout_for_action( 'edit' )['sidebar']['actions']
+        );
+    }
+
+    public function test_build_default_layout_section_contains_config_fields(): void {
+        $structure = $this->build_default_layout_for_action( 'edit' );
+
+        $section = $structure['items'][0];
+        $this->assertEquals( 1, count( $structure['items'] ) );
+        $this->assertEquals( 2, count( $section['fields'] ) );
+
+        $field_slugs = array_column( $section['fields'], 'slug' );
+
+        $this->assertEquals( 'section', $section['type'] );
+        $this->assertEquals( [ 'title', 'author' ], $field_slugs );
     }
 
     /**

--- a/tests/phpunit/data-view.php
+++ b/tests/phpunit/data-view.php
@@ -700,14 +700,6 @@ class DataView_TestCase extends \WP_UnitTestCase {
         $this->assertStringContainsString( 'id=42', $url );
     }
 
-    public function test_url_builder_generates_nonce_action(): void {
-        $builder = new UrlBuilder( 'my_page' );
-
-        $this->assertEquals( 'my_page_create', $builder->get_nonce_action( 'create' ) );
-        $this->assertEquals( 'my_page_edit_42', $builder->get_nonce_action( 'edit', 42 ) );
-        $this->assertEquals( 'my_page_delete_5', $builder->get_nonce_action( 'delete', 5 ) );
-    }
-
     /**
      * ==========================================================================
      * DataView with CPT Storage Tests
@@ -1262,6 +1254,18 @@ class DataView_TestCase extends \WP_UnitTestCase {
         $result = $handler2->read( $id );
         $this->assertTrue( $result->is_success() );
         $this->assertEquals( 'Test Item', $result->get_entity()->get( 'name' ) );
+    }
+
+    public function test_data_view_config_generates_nonce_action(): void {
+        $config = new DataViewConfig( [
+            'slug'   => 'test_view',
+            'label'  => 'Test',
+            'fields' => [ 'name' => 'string' ],
+        ] );
+
+        $this->assertEquals( 'test_view_create', $config->get_nonce_action( 'create' ) );
+        $this->assertEquals( 'test_view_edit_42', $config->get_nonce_action( 'edit', 42 ) );
+        $this->assertEquals( 'test_view_delete_5', $config->get_nonce_action( 'delete', 5 ) );
     }
 
     /**


### PR DESCRIPTION
Hi @zinigor!

As I mentioned in [this comment](https://github.com/TangibleInc/object/pull/36#issue-4504532538) on a previous pull request, I think we need to update the way we handle nonces

This pull request does the following changes:
-  Move `get_nonce_action()` from `UrlBuilder` to `DataViewConfig`
-  In the default layout, display action buttons according to current action
- Switch from the default input name for nonces (`_wpnonce`) to use an action specific one (`_wpnonce_{action})`)

The reason I moved `get_nonce_action()` away from `UrlBuilder` is because we also use it to generate nonce fields in our POST `<form>`, and as it relies on `get_menu_page()` to generate the nonce action name I thought it could make sense to move it to `DataViewConfig` (honestly wasn't really sure what would be the best place)

The default layout was returning a "Save" and "Delete" button for the create action, we should now display only a "Create" button instead

Lastly, it switch from the default name for the nonce field (`_wpnonce`) to an action specific name. It was causing issues in the edit form, as we need a 2 nonce fields (2 actions in the same form: edit and delete). Both actions require a different nonce in the backend ([here](https://github.com/TangibleInc/object/blob/8a026c97dee880fe3f58d55220e6dd77315a5db1/src/DataView/RequestRouter.php#L334-L336) and [here](https://github.com/TangibleInc/object/blob/8a026c97dee880fe3f58d55220e6dd77315a5db1/src/DataView/RequestRouter.php#L359-L361)), so we have to use a different name otherwise the second nonce will overwrite the first one