### PR TITLE
TangibleFieldsRenderer: Sections and Tabs - Switch to uncontrolled fields

### DIFF
--- a/src/Renderer/TangibleFieldsRenderer.php
+++ b/src/Renderer/TangibleFieldsRenderer.php
@@ -143,12 +143,11 @@ class TangibleFieldsRenderer implements Renderer {
         $section_id = sanitize_key( $section['label'] ) . '_' . uniqid();
 
         return $fields->render_field( $section_id, [
-            'type'   => 'accordion',
-            'label'  => $section['label'],
-            'value'  => true,
-            'isOpen' => true, // Expanded by default.
-            'fields' => $section_fields,
-            ...$this->get_memory_store_callbacks(),
+            'type'         => 'accordion',
+            'label'        => $section['label'],
+            'isOpen'       => true, // Expanded by default.
+            'uncontrolled' => true,
+            'fields'       => $section_fields,
         ] );
     }
 
@@ -176,11 +175,11 @@ class TangibleFieldsRenderer implements Renderer {
 
             // Wrap in an accordion to preserve the section label.
             $fields[] = [
-                'type'   => 'accordion',
-                'label'  => $item['label'],
-                'title'  => $item['label'],
-                'value'  => true, // Expanded by default.
-                'fields' => $section_fields,
+                'type'         => 'accordion',
+                'label'        => $item['label'],
+                'title'        => $item['label'],
+                'uncontrolled' => true,
+                'fields'       => $section_fields,
             ];
         } elseif ( $item['type'] === 'tabs' ) {
             foreach ( $item['tabs'] ?? [] as $tab ) {
@@ -234,9 +233,9 @@ class TangibleFieldsRenderer implements Renderer {
         $tabs_id = 'tabs_' . uniqid();
 
         return $fields->render_field( $tabs_id, [
-            'type' => 'tab',
-            'tabs' => $tabs,
-            ...$this->get_memory_store_callbacks(),
+            'type'         => 'tab',
+            'tabs'         => $tabs,
+            'uncontrolled' => true,
         ] );
     }
 
@@ -369,7 +368,6 @@ class TangibleFieldsRenderer implements Renderer {
             'value'       => $this->format_value_for_field( $value, $type ),
             'description' => $field['help'] ?? $config['description'] ?? '',
             'placeholder' => $field['placeholder'] ?? $config['placeholder'] ?? '',
-            ...$this->get_memory_store_callbacks(),
         ];
 
         // Add type-specific options.
@@ -413,7 +411,6 @@ class TangibleFieldsRenderer implements Renderer {
             'value'      => $value,
             'sub_fields' => $sub_fields,
             'layout'     => $config['layout'] ?? 'table',
-            ...$this->get_memory_store_callbacks(),
         ];
 
         // Optional repeater settings.
@@ -643,25 +640,6 @@ class TangibleFieldsRenderer implements Renderer {
     protected function get_default_value( string $slug ): mixed {
         $config = $this->field_configs[ $slug ] ?? [];
         return $config['default'] ?? null;
-    }
-
-    /**
-     * Get memory store callbacks for Tangible Fields.
-     *
-     * We use memory store because DataView handles persistence.
-     *
-     * @return array Store and permission callbacks.
-     */
-    protected function get_memory_store_callbacks(): array {
-        $fields = tangible_fields();
-
-        return [
-            ...$fields->_store_callbacks['memory'](),
-            ...$fields->_permission_callbacks( [
-                'store' => [ 'always_allow' ],
-                'fetch' => [ 'always_allow' ],
-            ] ),
-        ];
     }
 
     /**

--- a/src/Renderer/TangibleFieldsRenderer.php
+++ b/src/Renderer/TangibleFieldsRenderer.php
@@ -29,11 +29,6 @@ class TangibleFieldsRenderer implements Renderer {
     protected array $field_configs = [];
 
     /**
-     * Whether assets have been enqueued.
-     */
-    protected bool $enqueued = false;
-
-    /**
      * Type mapping: DataView type => Tangible Fields type.
      */
     protected array $type_map = [
@@ -94,9 +89,6 @@ class TangibleFieldsRenderer implements Renderer {
         }
 
         $html .= '</div>';
-
-        // Schedule asset enqueueing.
-        $this->schedule_enqueue();
 
         return $html;
     }
@@ -716,31 +708,13 @@ class TangibleFieldsRenderer implements Renderer {
     }
 
     /**
-     * Enqueue Tangible Fields assets.
+     * Required by the interface, but enqueue logic will be handled by
+     * the fields module
+     *
+     * @see https://github.com/TangibleInc/fields/blob/main/enqueue.php
      */
     public function enqueue_assets(): void {
-        if ( $this->enqueued ) {
-            return;
-        }
-
         $this->ensure_tangible_fields_loaded();
-
-        $fields = tangible_fields();
-        $fields->enqueue();
-
-        $this->enqueued = true;
-    }
-
-    /**
-     * Schedule asset enqueueing for the footer.
-     */
-    protected function schedule_enqueue(): void {
-        if ( $this->enqueued ) {
-            return;
-        }
-
-        // Enqueue in footer to ensure all fields are registered.
-        add_action( 'admin_footer', [ $this, 'enqueue_assets' ], 5 );
     }
 
     /**

--- a/tests/phpunit/data-view.php
+++ b/tests/phpunit/data-view.php
@@ -1570,7 +1570,7 @@ class DataView_TestCase extends \WP_UnitTestCase {
         $this->assertArrayHasKey( 'title', $result[0] ); // Required by Fields library.
         $this->assertEquals( 'Contact Info', $result[0]['title'] );
         $this->assertEquals( 'Contact Info', $result[0]['label'] );
-        $this->assertTrue( $result[0]['value'] ); // Expanded by default.
+        $this->assertTrue( $result[0]['uncontrolled'] );
         $this->assertArrayHasKey( 'fields', $result[0] );
         $this->assertCount( 2, $result[0]['fields'] );
     }


### PR DESCRIPTION
Hi @zinigor!

The way `accordions` and `tabs` worked in fields was not really compatible with the way we use them in the object module

They were both expecting a value, which takes the form of a JSON object that holds the value of each sub-field

As we were not passing this initial value, all fields were blank regardless of what was previously saved

I updated the fields module and added the possibility to have an "uncontrolled" mode for both the `accordion` and `tab` fields, with that mode they should not expect a value and sub-fields will be populated

It's not directly related, but I took the opportunity to remove the permission and store callbacks, as we don't rely on fields for saving data we can safely remove them

I also simplified the enqueue logic, as we can rely on fields to enqueue its assets when something is being rendered