### PR TITLE
HtmlRenderer: submit type for create and edit action buttons

### DIFF
--- a/src/Renderer/HtmlRenderer.php
+++ b/src/Renderer/HtmlRenderer.php
@@ -189,7 +189,7 @@ class HtmlRenderer implements Renderer {
      * @return string The rendered HTML.
      */
     protected function render_action( string $action ): string {
-        $type = ( $action === 'save' ) ? 'submit' : 'button';
+        $type = in_array( $action, [ 'save', 'create', 'edit' ], true ) ? 'submit' : 'button';
         $label = ucfirst( $action );
 
         return '<button type="' . $type . '" name="action" value="' . $this->escape( $action ) . '">' . $this->escape( $label ) . '</button>';


### PR DESCRIPTION
## Bug

`HtmlRenderer::render_action()` sets `type="submit"` only for the `save` action; `create` and `edit` fall through to `type="button"`. A `type=button` button submits nothing, so any form rendered by `HtmlRenderer` whose action is `create`/`edit` is a **dead button** — clicking it does nothing (no POST, no navigation, no network request).

Concretely: the DataView **"Add New" create form** can't create anything — Create is a dead button. (The `TangibleFieldsRenderer` already maps create/save to submit; only `HtmlRenderer` was missing it.)

## Fix

```php
- $type = ( $action === 'save' ) ? 'submit' : 'button';
+ $type = in_array( $action, [ 'save', 'create', 'edit' ], true ) ? 'submit' : 'button';
```

`route_plural()` already handles the `create`/`edit` POST submissions, so this just lets the buttons actually post. Purely additive: `save` unchanged, custom JS actions stay `button`.

`delete` is intentionally left as `button` — this renderer adds no confirm `onclick`, so making it a bare submit would be a no-confirm delete. Deletion is handled via list-view links.