### PR TITLE
Added an array type of field to store nested values.

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,7 +1,0 @@
-{
-  "permissions": {
-    "allow": [
-      "Bash(tree:*)"
-    ]
-  }
-}

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,7 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(tree:*)"
+    ]
+  }
+}

--- a/src/DataObject/DataSet.php
+++ b/src/DataObject/DataSet.php
@@ -15,6 +15,7 @@ class DataSet {
     public const TYPE_STRING = 'string';
     public const TYPE_INTEGER = 'int';
     public const TYPE_BOOLEAN = 'bool';
+    public const TYPE_ARRAY = 'array';
 
     /**
      * @var array
@@ -77,6 +78,21 @@ class DataSet {
     }
 
     /**
+     * Add an array based field to the dataset.
+     *
+     * Array fields hold structured (nested) values such as associative maps
+     * and are stored as-is. Their values pass through coercion untouched.
+     *
+     * @param String $slug the field name.
+     */
+    public function add_array( string $slug ) {
+        $this->fields[ $slug ] = [
+            'type' => self::TYPE_ARRAY,
+        ];
+        return $this;
+    }
+
+    /**
      * Coerce a value to the correct type based on field definition.
      *
      * @param string $slug the field name.
@@ -94,6 +110,7 @@ class DataSet {
             self::TYPE_STRING  => (string) $value,
             self::TYPE_INTEGER => (int) $value,
             self::TYPE_BOOLEAN => $this->coerce_boolean( $value ),
+            self::TYPE_ARRAY   => is_array( $value ) ? $value : [],
             default            => $value,
         };
     }

--- a/src/DataView/DataView.php
+++ b/src/DataView/DataView.php
@@ -106,6 +106,7 @@ class DataView {
                 DataSet::TYPE_STRING  => $this->dataset->add_string( $name ),
                 DataSet::TYPE_INTEGER => $this->dataset->add_integer( $name ),
                 DataSet::TYPE_BOOLEAN => $this->dataset->add_boolean( $name ),
+                DataSet::TYPE_ARRAY   => $this->dataset->add_array( $name ),
             };
         }
     }

--- a/src/DataView/FieldTypeRegistry.php
+++ b/src/DataView/FieldTypeRegistry.php
@@ -79,6 +79,18 @@ class FieldTypeRegistry {
                 'schema'    => [ 'type' => 'longtext' ],
                 'input'     => 'repeater',
             ],
+            'map' => [
+                'dataset'   => DataSet::TYPE_ARRAY,
+                'sanitizer' => [ $this, 'sanitize_map' ],
+                'schema'    => [ 'type' => 'longtext' ],
+                'input'     => 'hidden',
+            ],
+            'boolean_map' => [
+                'dataset'   => DataSet::TYPE_ARRAY,
+                'sanitizer' => [ $this, 'sanitize_boolean_map' ],
+                'schema'    => [ 'type' => 'longtext' ],
+                'input'     => 'hidden',
+            ],
         ];
     }
 
@@ -251,5 +263,61 @@ class FieldTypeRegistry {
 
             return $sanitized;
         }, $rows ) );
+    }
+
+    /**
+     * Sanitize an associative map value from POST data.
+     *
+     * Keeps the nested array shape (string keys mapped to scalar values),
+     * recursing into nested maps. Values are limited to JSON-compatible
+     * primitives; strings are run through sanitize_text_field.
+     *
+     * @param mixed $value Value to sanitize (associative array).
+     * @return array Sanitized associative array.
+     */
+    public function sanitize_map( mixed $value ): array {
+        if ( ! is_array( $value ) ) {
+            return [];
+        }
+
+        $sanitized = [];
+        foreach ( $value as $key => $item ) {
+            $key = is_string( $key ) ? sanitize_key( $key ) : $key;
+
+            if ( is_array( $item ) ) {
+                $sanitized[ $key ] = $this->sanitize_map( $item );
+            } elseif ( is_string( $item ) ) {
+                $sanitized[ $key ] = sanitize_text_field( $item );
+            } elseif ( is_int( $item ) || is_float( $item ) || is_bool( $item ) || is_null( $item ) ) {
+                $sanitized[ $key ] = $item;
+            }
+            // Skip any other types for security.
+        }
+
+        return $sanitized;
+    }
+
+    /**
+     * Sanitize a map of boolean flags from POST data.
+     *
+     * Each value is coerced to a real boolean, so values submitted as the
+     * strings "1"/"0" (e.g. from hidden form inputs) are stored as true/false
+     * rather than truthy strings.
+     *
+     * @param mixed $value Value to sanitize (associative array of flags).
+     * @return array<string, bool> Sanitized map of booleans.
+     */
+    public function sanitize_boolean_map( mixed $value ): array {
+        if ( ! is_array( $value ) ) {
+            return [];
+        }
+
+        $sanitized = [];
+        foreach ( $value as $key => $item ) {
+            $key = is_string( $key ) ? sanitize_key( $key ) : $key;
+            $sanitized[ $key ] = $this->sanitize_boolean( $item );
+        }
+
+        return $sanitized;
     }
 }

--- a/tests/phpunit/data-object.php
+++ b/tests/phpunit/data-object.php
@@ -84,6 +84,38 @@ class DataObject_TestCase extends \WP_UnitTestCase {
         $this->assertEquals(DataSet::TYPE_BOOLEAN, $fields['is_active']['type']);
     }
 
+    public function test_dataset_can_add_array_field(): void {
+        $dataset = new DataSet();
+        $dataset->add_array('post_types');
+
+        $fields = $dataset->get_fields();
+        $this->assertArrayHasKey('post_types', $fields);
+        $this->assertEquals(DataSet::TYPE_ARRAY, $fields['post_types']['type']);
+    }
+
+    public function test_dataset_coerces_array_field_as_passthrough(): void {
+        $dataset = new DataSet();
+        $dataset->add_array('post_types');
+
+        $value = ['posts' => true, 'pages' => false];
+        $this->assertSame($value, $dataset->coerce('post_types', $value));
+
+        // Non-array values coerce to an empty array.
+        $this->assertSame([], $dataset->coerce('post_types', 'nonsense'));
+    }
+
+    public function test_singular_object_can_save_and_retrieve_array_value(): void {
+        $dataset = new DataSet();
+        $dataset->add_array('post_types');
+
+        $object = new SingularObject('test_settings');
+        $object->set_dataset($dataset);
+
+        $value = ['posts' => true, 'pages' => false];
+        $object->set('post_types', $value);
+        $this->assertSame($value, $object->get('post_types'));
+    }
+
     public function test_dataset_can_add_multiple_fields(): void {
         $dataset = new DataSet();
         $dataset->add_string('title');

--- a/tests/phpunit/data-view.php
+++ b/tests/phpunit/data-view.php
@@ -211,6 +211,88 @@ class DataView_TestCase extends \WP_UnitTestCase {
         $this->assertFalse( $sanitizer( 'no' ) );
     }
 
+    public function test_field_type_registry_has_map_types(): void {
+        $registry = new FieldTypeRegistry();
+
+        $this->assertTrue( $registry->has_type( 'map' ) );
+        $this->assertTrue( $registry->has_type( 'boolean_map' ) );
+
+        $this->assertEquals( DataSet::TYPE_ARRAY, $registry->get_dataset_type( 'map' ) );
+        $this->assertEquals( DataSet::TYPE_ARRAY, $registry->get_dataset_type( 'boolean_map' ) );
+    }
+
+    public function test_map_sanitizer_keeps_nested_shape(): void {
+        $registry = new FieldTypeRegistry();
+        $sanitizer = $registry->get_sanitizer( 'map' );
+
+        $result = $sanitizer( [
+            'name'   => '<b>Hello</b>',
+            'count'  => 3,
+            'nested' => [ 'flag' => true, 'label' => 'ok' ],
+        ] );
+
+        $this->assertSame( 'Hello', $result['name'] );
+        $this->assertSame( 3, $result['count'] );
+        $this->assertSame( true, $result['nested']['flag'] );
+        $this->assertSame( 'ok', $result['nested']['label'] );
+    }
+
+    public function test_map_sanitizer_returns_empty_array_for_non_array(): void {
+        $registry = new FieldTypeRegistry();
+        $sanitizer = $registry->get_sanitizer( 'map' );
+
+        $this->assertSame( [], $sanitizer( 'not-an-array' ) );
+        $this->assertSame( [], $sanitizer( null ) );
+    }
+
+    public function test_boolean_map_sanitizer_coerces_values_to_real_booleans(): void {
+        $registry = new FieldTypeRegistry();
+        $sanitizer = $registry->get_sanitizer( 'boolean_map' );
+
+        // Values arrive as "1"/"0" strings from hidden form inputs.
+        $result = $sanitizer( [
+            'posts'  => '1',
+            'pages'  => '0',
+            'media'  => 'on',
+            'groups' => '',
+        ] );
+
+        $this->assertSame( true, $result['posts'] );
+        $this->assertSame( false, $result['pages'], 'String "0" must become real false, not a truthy string' );
+        $this->assertSame( true, $result['media'] );
+        $this->assertSame( false, $result['groups'] );
+    }
+
+    public function test_array_field_round_trips_through_dataview_and_option_storage(): void {
+        // Proves the TYPE_ARRAY primitive: a nested array value passes through
+        // coercion untouched and is persisted as a nested array by OptionStorage.
+        // (Boolean coercion is the sanitizer's job, exercised in extract_post_data;
+        // here the handler receives already-sanitized values.)
+        $config = [
+            'slug'    => 'dv_test_map_roundtrip',
+            'label'   => 'Settings',
+            'mode'    => 'singular',
+            'storage' => 'option',
+            'fields'  => [
+                'post_types' => 'boolean_map',
+            ],
+        ];
+
+        $view    = new DataView( $config );
+        $handler = $view->get_handler();
+
+        $result = $handler->update( [
+            'post_types' => [ 'posts' => true, 'pages' => false ],
+        ] );
+
+        $this->assertTrue( $result->is_success() );
+
+        $stored = get_option( 'dv_test_map_roundtrip' );
+        $this->assertIsArray( $stored['post_types'] );
+        $this->assertSame( true, $stored['post_types']['posts'] );
+        $this->assertSame( false, $stored['post_types']['pages'] );
+    }
+
     public function test_field_type_registry_has_repeater_type(): void {
         $registry = new FieldTypeRegistry();
 


### PR DESCRIPTION
### Changes

This PR adds a reusable array-valued field primitive so settings with nested structure can persist natively without overrides or flattening:

- `DataSet` — new `TYPE_ARRAY` constant + `add_array()`. `coerce()` passes arrays through untouched (non-arrays get an empty `[]`).
- `DataView::build_dataset()` — added the `TYPE_ARRAY` arm so a field declared with an array-backed type no longer throws `UnhandledMatchError`.
- `FieldTypeRegistry` — two reusable types backed by `TYPE_ARRAY`:
  - `map` — generic associative map; recursively sanitizes scalar values (strings via sanitize_text_field, keeps int/float/bool/null).
  - `boolean_map` — coerces each value to a real boolean, so form-submitted "1"/"0" strings persist as true/false.

The flow end-to-end: `extract_post_data()` runs the type's sanitizer (array → sanitized array) → coerce() passes it through → `OptionStorage` stores the nested array via update_option. The persisted shape stays nested.
