### PR TITLE
DataView: add `notices` config to suppress built-in save notices

### DIFF
--- a/src/DataView/DataViewConfig.php
+++ b/src/DataView/DataViewConfig.php
@@ -16,6 +16,18 @@ class DataViewConfig {
     public readonly array $storage_options;
 
     /**
+     * Whether DataView renders its own success/error notices.
+     *
+     * Set to false when the host environment already renders save notices for
+     * this page — e.g. a settings page under the WordPress "Settings" menu,
+     * where core's options-head.php shows a native "Settings saved." notice for
+     * the `updated=1` redirect. Leaving this true there would double the notice.
+     *
+     * @var bool
+     */
+    public readonly bool $notices;
+
+    /**
      * Full field configurations including repeater sub-fields.
      *
      * Each entry is an array with at least 'type' key.
@@ -70,6 +82,7 @@ class DataViewConfig {
         $this->mode            = $config['mode'] ?? 'plural';
         $this->capability      = $config['capability'] ?? 'manage_options';
         $this->storage_options = $config['storage_options'] ?? [];
+        $this->notices         = $config['notices'] ?? true;
 
         // Parse field configurations (supports both simple and complex definitions).
         $this->field_configs = $this->parse_field_configs( $config['fields'] );

--- a/src/DataView/RequestRouter.php
+++ b/src/DataView/RequestRouter.php
@@ -600,6 +600,10 @@ class RequestRouter {
      * Render success/error notices from query params.
      */
     protected function render_notices(): void {
+        if ( ! $this->config->notices ) {
+            return;
+        }
+
         // phpcs:ignore WordPress.Security.NonceVerification.Recommended
         if ( isset( $_GET['created'] ) ) {
             echo '<div class="notice notice-success is-dismissible"><p>' . esc_html( $this->get_label( 'item_created' ) ) . '</p></div>';

--- a/tests/phpunit/data-view.php
+++ b/tests/phpunit/data-view.php
@@ -380,6 +380,75 @@ class DataView_TestCase extends \WP_UnitTestCase {
         return $property->getValue( $view );
     }
 
+    /**
+     * Render the protected notices output for a DataView's router.
+     */
+    private function render_notices_output( DataView $view ): string {
+        $router = $this->get_router( $view );
+        $method = new \ReflectionMethod( \Tangible\DataView\RequestRouter::class, 'render_notices' );
+        $method->setAccessible( true );
+
+        ob_start();
+        $method->invoke( $router );
+        return ob_get_clean();
+    }
+
+    public function test_notices_config_defaults_to_true(): void {
+        $config = new DataViewConfig( [
+            'slug'   => 'dv_test_notices_default',
+            'label'  => 'Settings',
+            'fields' => [ 'enabled' => 'boolean' ],
+        ] );
+
+        $this->assertTrue( $config->notices );
+    }
+
+    public function test_notices_config_can_be_disabled(): void {
+        $config = new DataViewConfig( [
+            'slug'     => 'dv_test_notices_off',
+            'label'    => 'Settings',
+            'fields'   => [ 'enabled' => 'boolean' ],
+            'notices'  => false,
+        ] );
+
+        $this->assertFalse( $config->notices );
+    }
+
+    public function test_render_notices_outputs_when_enabled(): void {
+        $_GET['updated'] = '1';
+
+        $view = new DataView( [
+            'slug'    => 'dv_test_notices_on_render',
+            'label'   => 'Settings',
+            'mode'    => 'singular',
+            'storage' => 'option',
+            'fields'  => [ 'enabled' => 'boolean' ],
+        ] );
+
+        $output = $this->render_notices_output( $view );
+        unset( $_GET['updated'] );
+
+        $this->assertStringContainsString( 'notice-success', $output );
+    }
+
+    public function test_render_notices_suppressed_when_disabled(): void {
+        $_GET['updated'] = '1';
+
+        $view = new DataView( [
+            'slug'     => 'dv_test_notices_off_render',
+            'label'    => 'Settings',
+            'mode'     => 'singular',
+            'storage'  => 'option',
+            'fields'   => [ 'enabled' => 'boolean' ],
+            'notices'  => false,
+        ] );
+
+        $output = $this->render_notices_output( $view );
+        unset( $_GET['updated'] );
+
+        $this->assertSame( '', $output, 'render_notices() must output nothing when notices are disabled' );
+    }
+
     public function test_field_type_registry_has_repeater_type(): void {
         $registry = new FieldTypeRegistry();
 


### PR DESCRIPTION
## Problem

When a `DataView` page lives under the WordPress **Settings** menu, two "Settings saved." notices appear after every save:

1. **WordPress core** — for pages under `options-general.php`, `admin-header.php` includes `wp-admin/options-head.php`, whose back-compat block fires for `?page=...&updated=1`:
   ```php
   if ( isset( $_GET['updated'] ) && isset( $_GET['page'] ) ) {
       // For back-compat with plugins that don't use the Settings API and just set updated=1 in the redirect.
       add_settings_error( 'general', 'settings_updated', __( 'Settings saved.' ), 'success' );
   }
   ```
   This is the native notice with `id="setting-error-settings_updated"`. DataView's redirect (`updated=1`) is exactly the case this path was written for.

2. **DataView** — `RequestRouter::render_notices()` also fires on `isset($_GET['updated'])`, echoing a second notice in the page body.

Both key on the same `?updated` param, so a consumer can't suppress just one.

## Change

Add a **`notices`** config option (bool, default `true`). When `false`, `render_notices()` returns early, letting the host environment own save notices:

```php
new DataView([
    'slug'    => 'my_settings',
    'mode'    => 'singular',
    'storage' => 'option',
    'notices' => false, // host (WP Settings) renders the save notice
    'fields'  => [ /* ... */ ],
]);
```

Validation/error output (`render_errors()`) is a separate path and is unaffected.

## Tests

4 new tests: config default (`true`), config override (`false`), and `render_notices()` output present-when-enabled / empty-when-disabled. Full suite: **274 passing**, 1 pre-existing unrelated skip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)