### PR TITLE
RequestRouter: Scope maybe_redirect to the DataView's own admin page

### DIFF
--- a/src/DataView/RequestRouter.php
+++ b/src/DataView/RequestRouter.php
@@ -144,6 +144,16 @@ class RequestRouter {
      * @param int|null $id Entity ID.
      */
     public function maybe_redirect(): void {
+        // maybe_redirect() is hooked on the global admin_init, so it fires on
+        // every admin request — including unrelated POSTs such as Gutenberg
+        // meta-box saves (post.php?meta-box-loader=1). Without this guard those
+        // POSTs get routed into handle_settings_submit()/handle_*_submit(),
+        // fail the DataView's own nonce check, and wp_die( 'Security check
+        // failed.' ) — breaking every meta-box save on the site. Only act when
+        // the request actually targets this DataView's own admin page.
+        $current_page = isset( $_GET['page'] ) ? sanitize_key( wp_unslash( $_GET['page'] ) ) : '';
+        if ( $current_page !== $this->config->get_menu_page() ) return;
+
         $this->check_capability();
 
         if ( ! $this->request->is_post() ) return;


### PR DESCRIPTION
## Problem

`RequestRouter::maybe_redirect()` is hooked on the global `admin_init` (#35), so it runs on **every** admin request. For a singular DataView it calls `handle_settings_submit()` on **any** admin POST with no check that the request actually targets its own page.

As a result, Gutenberg meta-box saves (`post.php?meta-box-loader=1`) get routed into the DataView's settings handler, fail its nonce check, and `wp_die( 'Security check failed.' )` — **breaking every meta-box save on the site** (HTTP 500) for any install that registers a singular DataView.

Same hazard applies to plural DataViews if a stray POST carries a `create`/`edit`/`delete` action.

## Fix

Bail out of `maybe_redirect()` unless `$_GET['page']` matches the DataView's own `menu_page`, before any capability check or submit handling. Real settings/create/edit submits post to `?page=<menu_page>&…`, so they still pass; unrelated admin POSTs (meta-box saves, other plugins' forms) are now ignored.

## Testing

Reproduced on a course edit screen (block editor): meta-box save returned 500 `Security check failed`, traced to `maybe_redirect()` → `handle_settings_submit()` → nonce fail. With this guard, the meta-box save completes and the DataView settings form still saves normally.