### PR TITLE
TangibleFieldsRenderer: Add support for visibility conditions

### DIFF
--- a/src/Renderer/TangibleFieldsRenderer.php
+++ b/src/Renderer/TangibleFieldsRenderer.php
@@ -360,6 +360,7 @@ class TangibleFieldsRenderer implements Renderer {
             'value'       => $this->format_value_for_field( $value, $type ),
             'description' => $field['help'] ?? $config['description'] ?? '',
             'placeholder' => $field['placeholder'] ?? $config['placeholder'] ?? '',
+            'condition'   => $config['condition'] ?? [],
         ];
 
         // Add type-specific options.
@@ -403,6 +404,7 @@ class TangibleFieldsRenderer implements Renderer {
             'value'      => $value,
             'sub_fields' => $sub_fields,
             'layout'     => $config['layout'] ?? 'table',
+            'condition'  => $config['condition'] ?? [],
         ];
 
         // Optional repeater settings.
@@ -439,9 +441,10 @@ class TangibleFieldsRenderer implements Renderer {
             $tf_type = $this->sub_field_type_map[ $type ] ?? 'text';
 
             $mapped_field = [
-                'type'  => $tf_type,
-                'name'  => $sub_field['name'],
-                'label' => $sub_field['label'] ?? ucfirst( str_replace( '_', ' ', $sub_field['name'] ) ),
+                'type'      => $tf_type,
+                'name'      => $sub_field['name'],
+                'label'     => $sub_field['label'] ?? ucfirst( str_replace( '_', ' ', $sub_field['name'] ) ),
+                'condition' => $sub_field['condition'] ?? [],
             ];
 
             // Add optional properties.
@@ -504,6 +507,7 @@ class TangibleFieldsRenderer implements Renderer {
                 'value'      => $value,
                 'sub_fields' => $sub_fields,
                 'layout'     => $config['layout'] ?? 'table',
+                'condition'  => $config['condition'] ?? [],
             ];
 
             if ( isset( $config['max_rows'] ) ) {
@@ -522,6 +526,7 @@ class TangibleFieldsRenderer implements Renderer {
             'value'       => $this->format_value_for_field( $value, $type ),
             'description' => $field['help'] ?? $config['description'] ?? '',
             'placeholder' => $field['placeholder'] ?? $config['placeholder'] ?? '',
+            'condition'   => $config['condition'] ?? [],
         ];
 
         // Add type-specific options.

--- a/tests/phpunit/data-view.php
+++ b/tests/phpunit/data-view.php
@@ -33,6 +33,14 @@ use Tangible\RequestHandler\Validators;
  */
 class DataView_TestCase extends \WP_UnitTestCase {
 
+    public function setUp(): void {
+        parent::setUp();
+
+        if ( function_exists( 'tangible_fields' ) ) {
+            tangible_fields()->registered_fields = [];
+        }
+    }
+
     /**
      * ==========================================================================
      * FieldTypeRegistry Tests
@@ -1841,6 +1849,234 @@ class DataView_TestCase extends \WP_UnitTestCase {
         $this->assertStringContainsString( '<button', $custom_html );
         $this->assertStringContainsString( 'value="archive"', $custom_html );
         $this->assertStringContainsString( '>Archive</button>', $custom_html );
+    }
+
+    /**
+     * ==========================================================================
+     * TangibleFieldsRenderer Conditional Visibility Tests
+     * ==========================================================================
+     */
+
+    /**
+     * @dataProvider condition_provider
+     */
+    public function test_renderer_forwards_condition(
+        array $field_configs,
+        callable $build_layout,
+        string $lookup,
+        array $expected
+    ): void {
+        if ( ! function_exists( 'tangible_fields' ) ) {
+            $this->markTestSkipped( 'Tangible Fields framework is not loaded.' );
+        }
+
+        $dataset = new DataSet();
+        foreach ( array_keys( $field_configs ) as $slug ) {
+            $dataset->add_string( $slug );
+        }
+
+        $layout = new Layout( $dataset );
+        $build_layout( $layout );
+
+        $renderer = new \Tangible\Renderer\TangibleFieldsRenderer();
+        $renderer->set_field_configs( $field_configs );
+
+        $renderer->render_editor( $layout, [] );
+
+        $config = $this->find_registered_field( $lookup );
+        $this->assertNotNull( $config, "Field '{$lookup}' should be registered with Tangible Fields" );
+        $this->assertEquals( $expected, $config['condition'] );
+    }
+
+    public function condition_provider(): array {
+        $condition = [
+            'action'    => 'show',
+            'condition' => [ 'condition_flag' => [ '_eq' => 'true' ] ],
+        ];
+
+        // Use same subfield for every repeater case
+        $sub_fields = [
+            [ 'name' => 'enabled', 'type' => 'boolean' ],
+            [ 'name' => 'amount', 'type' => 'integer', 'condition' => $condition ],
+        ];
+
+        $in_section = fn( $layout, $slug ) => (
+            $layout->section(
+                'General',
+                fn( $section ) => $section->field( $slug )
+            )
+        );
+        $in_sidebar = fn( $layout, $slug ) => (
+            $layout->sidebar(
+                fn( $sidebar ) => $sidebar->field( $slug )
+            )
+        );
+
+        /**
+         * Each case is:
+         * - field_configs  => configs registered on the renderer
+         * - build_layout   => places the field(s) in the layout
+         * - lookup         => field name to find in the registered tree
+         * - expected       => condition expected on that field (empty array when none set)
+         */
+        return [
+
+            'field forwards condition' => [
+                [
+                    'condition_field' => [
+                        'type'      => 'string',
+                        'condition' => $condition
+                    ]
+                ],
+                fn( $layout ) => $in_section( $layout, 'condition_field' ),
+                'condition_field',
+                $condition,
+            ],
+
+            'field absent defaults to empty' => [
+                [
+                    'condition_field' => [
+                        'type' => 'string'
+                    ]
+                ],
+                fn( $layout ) => $in_section( $layout, 'condition_field' ),
+                'condition_field',
+                [],
+            ],
+
+            'field in tab' => [
+                [
+                    'condition_field' => [
+                        'type'      => 'string',
+                        'condition' => $condition
+                    ]
+                ],
+                fn( $layout ) => $layout->tabs(
+                    fn( $tabs ) => $tabs->tab(
+                        'Main',
+                        fn( $tab ) => $tab->field( 'condition_field' )
+                    )
+                ),
+                'condition_field',
+                $condition,
+            ],
+
+            'field in nested section' => [
+                [
+                    'condition_field' => [
+                        'type'      => 'string',
+                        'condition' => $condition
+                    ]
+                ],
+                fn( $layout ) => $layout->section(
+                    'Outer',
+                    fn( $section ) => $section->section(
+                        'Inner',
+                        fn( $inner ) => $inner->field( 'condition_field' )
+                    )
+                ),
+                'condition_field',
+                $condition,
+            ],
+
+            'field in sidebar' => [
+                [
+                    'condition_field' => [
+                        'type'      => 'string',
+                        'condition' => $condition
+                    ]
+                ],
+                fn( $layout ) => $in_sidebar( $layout, 'condition_field' ),
+                'condition_field',
+                $condition,
+            ],
+
+            'repeater forwards condition' => [
+                [
+                    'condition_rows' => [
+                        'type'       => 'repeater',
+                        'sub_fields' => $sub_fields,
+                        'condition'  => $condition
+                    ]
+                ],
+                fn( $layout ) => $in_section( $layout, 'condition_rows' ),
+                'condition_rows',
+                $condition,
+            ],
+
+            'repeater in sidebar forwards condition' => [
+                [
+                    'condition_rows' => [
+                        'type'       => 'repeater',
+                        'sub_fields' => $sub_fields,
+                        'condition'  => $condition
+                    ]
+                ],
+                fn( $layout ) => $in_sidebar( $layout, 'condition_rows' ),
+                'condition_rows',
+                $condition,
+            ],
+
+            'repeater sub-field forwards condition' => [
+                [
+                    'condition_rows' => [
+                        'type'       => 'repeater',
+                        'sub_fields' => $sub_fields
+                    ]
+                ],
+                fn( $layout ) => $in_section( $layout, 'condition_rows' ),
+                'amount',
+                $condition,
+            ],
+
+            'repeater sub-field absent defaults to empty' => [
+                [
+                    'condition_rows' => [
+                        'type'       => 'repeater',
+                        'sub_fields' => $sub_fields
+                    ]
+                ],
+                fn( $layout ) => $in_section( $layout, 'condition_rows' ),
+                'enabled',
+                [],
+            ],
+        ];
+    }
+
+    /**
+     * Find a field config by name anywhere in the registered fields tree
+     * (top-level fields, section/tab children, repeater sub-fields).
+     *
+     * The root call omits $configs; recursion passes the subtree to search.
+     */
+    private function find_registered_field( string $name, ?array $configs = null ): ?array {
+        foreach ( $configs ?? tangible_fields()->registered_fields as $config ) {
+            if ( ! is_array( $config ) ) {
+                continue;
+            }
+
+            if ( ( $config['name'] ?? null ) === $name ) {
+                return $config;
+            }
+
+            foreach ( [ 'fields', 'sub_fields' ] as $children ) {
+                if ( ! empty( $config[ $children ] ) && is_array( $config[ $children ] )
+                    && $found = $this->find_registered_field( $name, $config[ $children ] )
+                ) {
+                    return $found;
+                }
+            }
+
+            foreach ( $config['tabs'] ?? [] as $tab ) {
+                if ( ! empty( $tab['fields'] ) 
+                    && $found = $this->find_registered_field( $name, $tab['fields'] )
+                ) {
+                    return $found;
+                }
+            }
+        }
+
+        return null;
     }
 
     /**


### PR DESCRIPTION
Hi @zinigor!

This pull request adds support for visibility conditions in the TangibleFieldsRenderer

Tangible fields has a visibility conditions system (evaluated on the frontend), that can be defined with the following syntax:
```php
  $fields->render_field( 'field-name', [
      'type'      => 'text',
      'condition' => [
          'action'    => 'show',
          'condition' => [ 'another-field-name' => [ '_eq' => 'value' ] ],
      ],
  ] );

  $fields->render_field( 'another-field-name', [
      'type' => 'text',
  ] );
```

Currently if we try to set those conditions in the DataView config, they won't be passed to `$fields->render_field()`:
```php
 new DataView([
      // ...
      'fields' => [
          'field-name' => [
              'type'      => 'text',
              // ...
              'condition' => [
                  'action'    => 'show',
                  'condition' => [ 'another-field-name' => [ '_eq' => 'value' ] ],
              ],
          ],
          'another-field-name' => 'string',
      ],
      // ...
  ]);
```

The changes just make sure we pass the conditions when they are defined