### PR TITLE
TangibleFieldsRenderer: Centralize fields args formatting

### DIFF
--- a/src/Renderer/TangibleFieldsRenderer.php
+++ b/src/Renderer/TangibleFieldsRenderer.php
@@ -326,103 +326,10 @@ class TangibleFieldsRenderer implements Renderer {
      * @return string The rendered HTML.
      */
     protected function render_field( array $field ): string {
-        $slug   = $field['slug'];
-        $type   = $this->get_field_type( $slug );
-        $value  = $this->data[ $slug ] ?? $this->get_default_value( $slug );
-        $config = $this->field_configs[ $slug ] ?? [];
-
-        if ( $type === 'repeater' ) {
-            return $this->render_repeater_field( $field, $value, $config );
-        }
-
-        return $this->render_simple_field( $field, $type, $value );
-    }
-
-    /**
-     * Render a simple (non-repeater) field.
-     *
-     * @param array  $field The field structure.
-     * @param string $type  The DataView field type.
-     * @param mixed  $value The field value.
-     * @return string The rendered HTML.
-     */
-    protected function render_simple_field( array $field, string $type, mixed $value ): string {
-        $fields         = tangible_fields();
-        $slug           = $field['slug'];
-        $tf_type        = $this->get_tangible_fields_type( $type );
-        $config         = $this->field_configs[ $slug ] ?? [];
-        $label          = $config['label'] ?? $field['label'] ?? ucfirst( str_replace( '_', ' ', $slug ) );
-
-        $field_args = [
-            'type'        => $tf_type,
-            'name'        => $slug,
-            'label'       => $label,
-            'value'       => $this->format_value_for_field( $value, $type ),
-            'description' => $field['help'] ?? $config['description'] ?? '',
-            'placeholder' => $field['placeholder'] ?? $config['placeholder'] ?? '',
-        ];
-
-        // Add type-specific options.
-        $field_args = $this->add_type_specific_options( $field_args, $type, $field, $config );
-
-        // Handle readonly.
-        if ( ! empty( $field['readonly'] ) ) {
-            $field_args['read_only'] = true;
-        }
-
-        return $fields->render_field( $slug, $field_args );
-    }
-
-    /**
-     * Render a repeater field.
-     *
-     * @param array $field  The field structure.
-     * @param mixed $value  The field value (JSON string or array).
-     * @param array $config The field configuration.
-     * @return string The rendered HTML.
-     */
-    protected function render_repeater_field( array $field, mixed $value, array $config ): string {
-        $fields     = tangible_fields();
-        $slug       = $field['slug'];
-        $label      = $config['label'] ?? $field['label'] ?? ucfirst( str_replace( '_', ' ', $slug ) );
-        $sub_fields = $this->map_sub_fields( $config['sub_fields'] ?? [] );
-
-        // Ensure value is a JSON string.
-        if ( is_array( $value ) ) {
-            $value = wp_json_encode( $value );
-        } elseif ( empty( $value ) ) {
-            // Use default value if provided.
-            $default = $config['default'] ?? [];
-            $value   = wp_json_encode( $default );
-        }
-
-        $field_args = [
-            'type'       => 'repeater',
-            'name'       => $slug,
-            'label'      => $label,
-            'value'      => $value,
-            'sub_fields' => $sub_fields,
-            'layout'     => $config['layout'] ?? 'table',
-        ];
-
-        // Optional repeater settings.
-        if ( isset( $config['max_rows'] ) ) {
-            $field_args['maxlength'] = $config['max_rows'];
-        }
-
-        if ( isset( $config['min_rows'] ) ) {
-            $field_args['minlength'] = $config['min_rows'];
-        }
-
-        if ( isset( $config['button_label'] ) ) {
-            $field_args['new_item'] = $config['button_label'];
-        }
-
-        if ( isset( $config['description'] ) ) {
-            $field_args['description'] = $config['description'];
-        }
-
-        return $fields->render_field( $slug, $field_args );
+        return tangible_fields()->render_field(
+            $field['slug'],
+            $this->build_field_config( $field )
+        );
     }
 
     /**
@@ -432,46 +339,26 @@ class TangibleFieldsRenderer implements Renderer {
      * @return array Tangible Fields sub-field configs.
      */
     protected function map_sub_fields( array $sub_fields ): array {
-        $mapped = [];
+        return array_map(
+            function ( array $sub_field ): array {
+                $type = $sub_field['type'] ?? 'string';
 
-        foreach ( $sub_fields as $sub_field ) {
-            $type    = $sub_field['type'] ?? 'string';
-            $tf_type = $this->sub_field_type_map[ $type ] ?? 'text';
-
-            $mapped_field = [
-                'type'  => $tf_type,
-                'name'  => $sub_field['name'],
-                'label' => $sub_field['label'] ?? ucfirst( str_replace( '_', ' ', $sub_field['name'] ) ),
-            ];
-
-            // Add optional properties.
-            if ( isset( $sub_field['placeholder'] ) ) {
-                $mapped_field['placeholder'] = $sub_field['placeholder'];
-            }
-
-            if ( isset( $sub_field['description'] ) ) {
-                $mapped_field['description'] = $sub_field['description'];
-            }
-
-            // Type-specific options.
-            if ( $tf_type === 'number' ) {
-                if ( isset( $sub_field['min'] ) ) {
-                    $mapped_field['min'] = $sub_field['min'];
+                if ( ! isset( $this->sub_field_type_map[ $type ] ) ) {
+                    throw new \InvalidArgumentException( sprintf(
+                        'Unsupported repeater sub-field type "%s" for "%s".',
+                        $type,
+                        $sub_field['name'] ?? ''
+                    ) );
                 }
-                if ( isset( $sub_field['max'] ) ) {
-                    $mapped_field['max'] = $sub_field['max'];
-                }
-            }
 
-            if ( $tf_type === 'switch' ) {
-                $mapped_field['value_on']  = true;
-                $mapped_field['value_off'] = false;
-            }
-
-            $mapped[] = $mapped_field;
-        }
-
-        return $mapped;
+                return $this->format_field_args(
+                    $type,
+                    $sub_field['name'],
+                    $sub_field
+                );
+            },
+            $sub_fields
+        );
     }
 
     /**
@@ -483,55 +370,71 @@ class TangibleFieldsRenderer implements Renderer {
     protected function build_field_config( array $field ): array {
         $slug   = $field['slug'];
         $type   = $this->get_field_type( $slug );
+        $config = $this->resolve_field_config( $field );
         $value  = $this->data[ $slug ] ?? $this->get_default_value( $slug );
-        $config = $this->field_configs[ $slug ] ?? [];
-        $label  = $config['label'] ?? $field['label'] ?? ucfirst( str_replace( '_', ' ', $slug ) );
 
-        if ( $type === 'repeater' ) {
-            $sub_fields = $this->map_sub_fields( $config['sub_fields'] ?? [] );
+        $args = $this->format_field_args( $type, $slug, $config, $field );
 
-            if ( is_array( $value ) ) {
-                $value = wp_json_encode( $value );
-            } elseif ( empty( $value ) ) {
-                $default = $config['default'] ?? [];
-                $value   = wp_json_encode( $default );
-            }
+        $args['value'] = $type === 'repeater'
+            ? $this->format_repeater_value( $value, $config )
+            : $this->format_value_for_field( $value, $type );
 
-            $field_config = [
-                'type'       => 'repeater',
-                'name'       => $slug,
-                'label'      => $label,
-                'value'      => $value,
-                'sub_fields' => $sub_fields,
-                'layout'     => $config['layout'] ?? 'table',
-            ];
+        return $args;
+    }
 
-            if ( isset( $config['max_rows'] ) ) {
-                $field_config['maxlength'] = $config['max_rows'];
-            }
+    /**
+     * Merge a Layout field with its registered config into one config array.
+     *
+     * The Layout structure and the registered field config both carry display
+     * keys (label, help/description, placeholder, readonly); this resolves their
+     * precedence so format_field_args has a single source to read from.
+     *
+     * @param array $field The field structure from Layout.
+     * @return array The merged config.
+     */
+    protected function resolve_field_config( array $field ): array {
+        $config = $this->field_configs[ $field['slug'] ] ?? [];
 
-            return $field_config;
-        }
+        return array_merge( $config, [
+            'label'       => $config['label'] ?? $field['label'] ?? null,
+            'description' => $field['help'] ?? $config['description'] ?? null,
+            'placeholder' => $field['placeholder'] ?? $config['placeholder'] ?? null,
+            'readonly'    => $field['readonly'] ?? $config['readonly'] ?? false,
+        ] );
+    }
 
-        $tf_type = $this->get_tangible_fields_type( $type );
-
-        $field_config = [
-            'type'        => $tf_type,
-            'name'        => $slug,
-            'label'       => $label,
-            'value'       => $this->format_value_for_field( $value, $type ),
-            'description' => $field['help'] ?? $config['description'] ?? '',
-            'placeholder' => $field['placeholder'] ?? $config['placeholder'] ?? '',
+    /**
+     * Build the field-definition args for a field or repeater sub-field, without its value.
+     *
+     * The caller attaches the value, since repeater sub-fields have none.
+     *
+     * @param string $type   The DataView field type.
+     * @param string $name   The field name.
+     * @param array  $config The field config / options source.
+     * @param array  $field  The Layout field structure (empty for sub-fields).
+     * @return array The Tangible Fields args.
+     */
+    protected function format_field_args(
+        string $type,
+        string $name,
+        array $config,
+        array $field = []
+    ): array {
+        $args = [
+            'type'        => $this->get_tangible_fields_type( $type ),
+            'name'        => $name,
+            'label'       => $config['label'] ?? ucfirst( str_replace( '_', ' ', $name ) ),
+            'description' => $config['description'] ?? '',
+            'placeholder' => $config['placeholder'] ?? '',
         ];
 
-        // Add type-specific options.
-        $field_config = $this->add_type_specific_options( $field_config, $type, $field, $config );
+        $args = $this->add_type_specific_options( $args, $type, $field, $config );
 
-        if ( ! empty( $field['readonly'] ) ) {
-            $field_config['read_only'] = true;
+        if ( ! empty( $config['readonly'] ) ) {
+            $args['read_only'] = true;
         }
 
-        return $field_config;
+        return $args;
     }
 
     /**
@@ -572,6 +475,21 @@ class TangibleFieldsRenderer implements Renderer {
                     $field_args['rows'] = $config['rows'];
                 }
                 break;
+
+            case 'repeater':
+                $field_args['sub_fields'] = $this->map_sub_fields( $config['sub_fields'] ?? [] );
+                $field_args['layout']     = $config['layout'] ?? 'table';
+
+                if ( isset( $config['max_rows'] ) ) {
+                    $field_args['maxlength'] = $config['max_rows'];
+                }
+                if ( isset( $config['min_rows'] ) ) {
+                    $field_args['minlength'] = $config['min_rows'];
+                }
+                if ( isset( $config['button_label'] ) ) {
+                    $field_args['new_item'] = $config['button_label'];
+                }
+                break;
         }
 
         return $field_args;
@@ -594,6 +512,24 @@ class TangibleFieldsRenderer implements Renderer {
             'integer' => (int) $value,
             default   => $value,
         };
+    }
+
+    /**
+     * Format a repeater value as the JSON string the field expects.
+     *
+     * @param mixed $value  The raw value.
+     * @param array $config The field configuration.
+     * @return string The JSON-encoded value.
+     */
+    protected function format_repeater_value( mixed $value, array $config ): string {
+        if ( is_array( $value ) ) {
+            return wp_json_encode( $value );
+        }
+        if ( empty( $value ) ) {
+            return wp_json_encode( $config['default'] ?? [] );
+        }
+
+        return (string) $value;
     }
 
     /**

--- a/tests/phpunit/data-view.php
+++ b/tests/phpunit/data-view.php
@@ -33,6 +33,14 @@ use Tangible\RequestHandler\Validators;
  */
 class DataView_TestCase extends \WP_UnitTestCase {
 
+    public function setUp(): void {
+        parent::setUp();
+
+        if ( function_exists( 'tangible_fields' ) ) {
+            tangible_fields()->registered_fields = [];
+        }
+    }
+
     /**
      * ==========================================================================
      * FieldTypeRegistry Tests
@@ -1841,6 +1849,285 @@ class DataView_TestCase extends \WP_UnitTestCase {
         $this->assertStringContainsString( '<button', $custom_html );
         $this->assertStringContainsString( 'value="archive"', $custom_html );
         $this->assertStringContainsString( '>Archive</button>', $custom_html );
+    }
+
+    /**
+     * Render a DataView definition through the renderer and assert the exact
+     * args each field ends up registered with in Tangible Fields.
+     *
+     * @dataProvider field_definition_provider
+     */
+    public function test_renderer_registers_expected_field_args(
+        array $field_configs,
+        array $data,
+        string $lookup,
+        array $expected
+    ): void {
+        if ( ! function_exists( 'tangible_fields' ) ) {
+            $this->markTestSkipped( 'Tangible Fields framework is not loaded.' );
+        }
+
+        $dataset = new DataSet();
+        foreach ( array_keys( $field_configs ) as $slug ) {
+            $dataset->add_string( $slug );
+        }
+
+        $layout = new Layout( $dataset );
+        $layout->section( 'General', function ( $section ) use ( $field_configs ) {
+            foreach ( array_keys( $field_configs ) as $slug ) {
+                $section->field( $slug );
+            }
+        } );
+
+        $renderer = new \Tangible\Renderer\TangibleFieldsRenderer();
+        $renderer->set_field_configs( $field_configs );
+        $renderer->render_editor( $layout, $data );
+
+        $config = $this->find_registered_field( $lookup );
+
+        $this->assertNotNull( $config, "Field '{$lookup}' should be registered" );
+        $this->assertEquals( $expected, $config );
+
+        // assertEquals is loose ( '5' == 5, '1' == true ), so pin the value's type
+        // strictly to actually validate the integer/boolean casts.
+        if ( array_key_exists( 'value', $expected ) ) {
+            $this->assertSame( $expected['value'], $config['value'] );
+        }
+    }
+
+    public function field_definition_provider(): array {
+
+        /**
+         * Each case is:
+         * - field_configs => configs registered on the renderer
+         * - data          => entity values, keyed by slug (drives value formatting)
+         * - lookup        => field name to find in the registered tree
+         * - expected      => the exact args that field should be registered with
+         */
+        return [
+
+            'string maps to text' => [
+                [ 'title' => [ 'type' => 'string' ] ],
+                [],
+                'title',
+                [
+                    'type'        => 'text',
+                    'name'        => 'title',
+                    'label'       => 'Title',
+                    'description' => '',
+                    'placeholder' => '',
+                    'value'       => '',
+                ],
+            ],
+
+            'text maps to textarea with rows' => [
+                [ 'body' => [ 'type' => 'text', 'rows' => 5 ] ],
+                [],
+                'body',
+                [
+                    'type'        => 'textarea',
+                    'name'        => 'body',
+                    'label'       => 'Body',
+                    'description' => '',
+                    'placeholder' => '',
+                    'rows'        => 5,
+                    'value'       => '',
+                ],
+            ],
+
+            'integer maps to number with min/max and casts value' => [
+                [ 'count' => [ 'type' => 'integer', 'min' => 0, 'max' => 10 ] ],
+                [ 'count' => '5' ],
+                'count',
+                [
+                    'type'        => 'number',
+                    'name'        => 'count',
+                    'label'       => 'Count',
+                    'description' => '',
+                    'placeholder' => '',
+                    'min'         => 0,
+                    'max'         => 10,
+                    'value'       => 5,
+                ],
+            ],
+
+            'boolean maps to switch and casts value' => [
+                [ 'active' => [ 'type' => 'boolean' ] ],
+                [ 'active' => '1' ],
+                'active',
+                [
+                    'type'        => 'switch',
+                    'name'        => 'active',
+                    'label'       => 'Active',
+                    'description' => '',
+                    'placeholder' => '',
+                    'value_on'    => true,
+                    'value_off'   => false,
+                    'value'       => true,
+                ],
+            ],
+
+            'date maps to date_picker with future_only' => [
+                [ 'due' => [ 'type' => 'date', 'future_only' => true ] ],
+                [],
+                'due',
+                [
+                    'type'        => 'date_picker',
+                    'name'        => 'due',
+                    'label'       => 'Due',
+                    'description' => '',
+                    'placeholder' => '',
+                    'future_only' => true,
+                    'value'       => '',
+                ],
+            ],
+
+            'label, description and placeholder overrides are honored' => [
+                [
+                    'email' => [
+                        'type'        => 'email',
+                        'label'       => 'E-mail',
+                        'description' => 'Contact',
+                        'placeholder' => 'you@example.com',
+                    ],
+                ],
+                [],
+                'email',
+                [
+                    'type'        => 'text',
+                    'name'        => 'email',
+                    'label'       => 'E-mail',
+                    'description' => 'Contact',
+                    'placeholder' => 'you@example.com',
+                    'value'       => '',
+                ],
+            ],
+
+            'readonly config sets read_only' => [
+                [ 'ref' => [ 'type' => 'string', 'readonly' => true ] ],
+                [],
+                'ref',
+                [
+                    'type'        => 'text',
+                    'name'        => 'ref',
+                    'label'       => 'Ref',
+                    'description' => '',
+                    'placeholder' => '',
+                    'read_only'   => true,
+                    'value'       => '',
+                ],
+            ],
+
+            'repeater carries all settings and maps sub-fields' => [
+                [
+                    'items' => [
+                        'type'         => 'repeater',
+                        'layout'       => 'table',
+                        'min_rows'     => 1,
+                        'max_rows'     => 5,
+                        'button_label' => 'Add row',
+                        'sub_fields'   => [
+                            [ 'name' => 'title', 'type' => 'string' ],
+                            [ 'name' => 'count', 'type' => 'integer', 'min' => 0 ],
+                        ],
+                    ],
+                ],
+                [],
+                'items',
+                [
+                    'type'        => 'repeater',
+                    'name'        => 'items',
+                    'label'       => 'Items',
+                    'description' => '',
+                    'placeholder' => '',
+                    'sub_fields'  => [
+                        [
+                            'type'        => 'text',
+                            'name'        => 'title',
+                            'label'       => 'Title',
+                            'description' => '',
+                            'placeholder' => '',
+                        ],
+                        [
+                            'type'        => 'number',
+                            'name'        => 'count',
+                            'label'       => 'Count',
+                            'description' => '',
+                            'placeholder' => '',
+                            'min'         => 0,
+                        ],
+                    ],
+                    'layout'      => 'table',
+                    'maxlength'   => 5,
+                    'minlength'   => 1,
+                    'new_item'    => 'Add row',
+                    'value'       => '[]',
+                ],
+            ],
+        ];
+    }
+
+    public function test_renderer_rejects_unsupported_repeater_sub_field_type(): void {
+        if ( ! function_exists( 'tangible_fields' ) ) {
+            $this->markTestSkipped( 'Tangible Fields framework is not loaded.' );
+        }
+
+        $renderer = new \Tangible\Renderer\TangibleFieldsRenderer();
+        $renderer->set_field_configs( [
+            'items' => [
+                'type'       => 'repeater',
+                'sub_fields' => [
+                    // Nested repeaters are unsupported: storage persists only flat scalar rows.
+                    [ 'name' => 'nested', 'type' => 'repeater', 'sub_fields' => [] ],
+                ],
+            ],
+        ] );
+
+        $dataset = new DataSet();
+        $dataset->add_string( 'items' );
+
+        $layout = new Layout( $dataset );
+        $layout->section( 'General', fn( $section ) => $section->field( 'items' ) );
+
+        $this->expectException( \InvalidArgumentException::class );
+        $this->expectExceptionMessage( 'Unsupported repeater sub-field type' );
+        $renderer->render_editor( $layout, [] );
+    }
+
+    /**
+     * Find a field config by name anywhere in the registered fields tree
+     * (top-level fields, section/tab children, repeater sub-fields).
+     *
+     * The root call omits $configs; recursion passes the subtree to search.
+     */
+    private function find_registered_field( string $name, ?array $configs = null ): ?array {
+        foreach ( $configs ?? tangible_fields()->registered_fields as $config ) {
+            if ( ! is_array( $config ) ) {
+                continue;
+            }
+
+            if ( ( $config['name'] ?? null ) === $name ) {
+                return $config;
+            }
+
+            foreach ( [ 'fields', 'sub_fields' ] as $children ) {
+                if ( ! empty( $config[ $children ] ) && is_array( $config[ $children ] )
+                    && $found = $this->find_registered_field( $name, $config[ $children ] )
+                ) {
+                    return $found;
+                }
+            }
+
+            foreach ( $config['tabs'] ?? [] as $tab ) {
+                if ( ! empty( $tab['fields'] ) && is_array( $tab['fields'] )
+                    && $found = $this->find_registered_field( $name, $tab['fields'] )
+                ) {
+                    return $found;
+                }
+            }
+        }
+
+        return null;
     }
 
     /**

--- a/tests/phpunit/data-view.php
+++ b/tests/phpunit/data-view.php
@@ -1896,7 +1896,6 @@ class DataView_TestCase extends \WP_UnitTestCase {
     }
 
     public function field_definition_provider(): array {
-
         /**
          * Each case is:
          * - field_configs => configs registered on the renderer
@@ -1917,6 +1916,7 @@ class DataView_TestCase extends \WP_UnitTestCase {
                     'description' => '',
                     'placeholder' => '',
                     'value'       => '',
+                    'condition'   => []
                 ],
             ],
 
@@ -1932,6 +1932,7 @@ class DataView_TestCase extends \WP_UnitTestCase {
                     'placeholder' => '',
                     'rows'        => 5,
                     'value'       => '',
+                    'condition'   => []
                 ],
             ],
 
@@ -1948,6 +1949,7 @@ class DataView_TestCase extends \WP_UnitTestCase {
                     'min'         => 0,
                     'max'         => 10,
                     'value'       => 5,
+                    'condition'   => []
                 ],
             ],
 
@@ -1964,6 +1966,7 @@ class DataView_TestCase extends \WP_UnitTestCase {
                     'value_on'    => true,
                     'value_off'   => false,
                     'value'       => true,
+                    'condition'   => []
                 ],
             ],
 
@@ -1979,6 +1982,7 @@ class DataView_TestCase extends \WP_UnitTestCase {
                     'placeholder' => '',
                     'future_only' => true,
                     'value'       => '',
+                    'condition'   => []
                 ],
             ],
 
@@ -2000,6 +2004,7 @@ class DataView_TestCase extends \WP_UnitTestCase {
                     'description' => 'Contact',
                     'placeholder' => 'you@example.com',
                     'value'       => '',
+                    'condition'   => []
                 ],
             ],
 
@@ -2015,6 +2020,7 @@ class DataView_TestCase extends \WP_UnitTestCase {
                     'placeholder' => '',
                     'read_only'   => true,
                     'value'       => '',
+                    'condition'   => []
                 ],
             ],
 
@@ -2040,6 +2046,7 @@ class DataView_TestCase extends \WP_UnitTestCase {
                     'label'       => 'Items',
                     'description' => '',
                     'placeholder' => '',
+                    'condition'   => [],
                     'sub_fields'  => [
                         [
                             'type'        => 'text',
@@ -2047,6 +2054,7 @@ class DataView_TestCase extends \WP_UnitTestCase {
                             'label'       => 'Title',
                             'description' => '',
                             'placeholder' => '',
+                            'condition'   => []
                         ],
                         [
                             'type'        => 'number',
@@ -2055,6 +2063,7 @@ class DataView_TestCase extends \WP_UnitTestCase {
                             'description' => '',
                             'placeholder' => '',
                             'min'         => 0,
+                            'condition'   => []
                         ],
                     ],
                     'layout'      => 'table',
@@ -2320,42 +2329,6 @@ class DataView_TestCase extends \WP_UnitTestCase {
                 [],
             ],
         ];
-    }
-
-    /**
-     * Find a field config by name anywhere in the registered fields tree
-     * (top-level fields, section/tab children, repeater sub-fields).
-     *
-     * The root call omits $configs; recursion passes the subtree to search.
-     */
-    private function find_registered_field( string $name, ?array $configs = null ): ?array {
-        foreach ( $configs ?? tangible_fields()->registered_fields as $config ) {
-            if ( ! is_array( $config ) ) {
-                continue;
-            }
-
-            if ( ( $config['name'] ?? null ) === $name ) {
-                return $config;
-            }
-
-            foreach ( [ 'fields', 'sub_fields' ] as $children ) {
-                if ( ! empty( $config[ $children ] ) && is_array( $config[ $children ] )
-                    && $found = $this->find_registered_field( $name, $config[ $children ] )
-                ) {
-                    return $found;
-                }
-            }
-
-            foreach ( $config['tabs'] ?? [] as $tab ) {
-                if ( ! empty( $tab['fields'] ) 
-                    && $found = $this->find_registered_field( $name, $tab['fields'] )
-                ) {
-                    return $found;
-                }
-            }
-        }
-
-        return null;
     }
 
     /**


### PR DESCRIPTION
~~Currently just a draft as it will conflict if [PR#50](https://github.com/TangibleInc/object/pull/50) is merged~~

I noticed we currently apply a similar formatting in different places for fields args:
- [render_simple_field()](https://github.com/TangibleInc/object/blob/55f015d0e81b8fa585446df13ae99774b4a55ad8/src/Renderer/TangibleFieldsRenderer.php#L356-L371)
- [map_sub_fields()](https://github.com/TangibleInc/object/blob/55f015d0e81b8fa585446df13ae99774b4a55ad8/src/Renderer/TangibleFieldsRenderer.php#L441-L471)
- [build_field_config()](https://github.com/TangibleInc/object/blob/55f015d0e81b8fa585446df13ae99774b4a55ad8/src/Renderer/TangibleFieldsRenderer.php#L500-L532)

This is just a proposition to centralize this behavior, and make sure we format fields and subfields consistently regardless of where they are rendered

I also added a throw when we attempt to use an unsupported field type as a repeater subfield ([here](https://github.com/TangibleInc/object/blob/b40ba1c7da620133abdd6f792385c249d527e7fb/src/Renderer/TangibleFieldsRenderer.php#L346-L352)) instead of a silent fallback to text, but it can be changed back if needed